### PR TITLE
[buteo-syncfw] Change QSet<int> for QFlags to stores days for schedul…

### DIFF
--- a/libbuteosyncfw/profile/SyncSchedule.h
+++ b/libbuteosyncfw/profile/SyncSchedule.h
@@ -26,7 +26,7 @@
 #define SYNCSCHEDULE_H
 
 #include <QTime>
-#include <QSet>
+#include <QFlags>
 
 class QDomDocument;
 class QDomElement;
@@ -35,8 +35,6 @@ namespace Buteo {
 
 class SyncSchedulePrivate;
 class SyncScheduleTest;
-
-typedef QSet<int> DaySet;
 
 const QString SYNC_SCHEDULE_ENABLED_KEY_BOOL("scheduler/schedule_enabled");
 const QString SYNC_SCHEDULE_PEAK_ENABLED_KEY_BOOL("scheduler/schedule_peak_enabled");
@@ -53,6 +51,18 @@ const QString SYNC_SCHEDULE_OFFPEAK_SCHEDULE_KEY_INT ("scheduler/schedule_off_pe
 class SyncSchedule
 {
 public:
+    enum Day {
+        NoDays    = 0x00,
+        Monday    = 0x01,
+        Tuesday   = 0x02,
+        Wednesday = 0x04,
+        Thursday  = 0x08,
+        Friday    = 0x10,
+        Saturday  = 0x20,
+        Sunday    = 0x40
+    };
+    Q_DECLARE_FLAGS(Days, Day)
+
     /*! \brief Constructs an empty schedule.
      *
      */
@@ -101,17 +111,16 @@ public:
 
     /*! \brief Gets the enabled week days of the sync schedule.
      *
-     * The returned set contains the numbers of enabled week days.
-     * Day numbers are defined in Qt::DayOfWeek.
-     * \return Set of week day numbers.
+     * Enabled week days are provided as a bitwise OR of SyncSchedule::Day.
+     * \return Set of week days.
      */
-    DaySet days() const;
+    Days days() const;
 
     /*! \brief Sets the enabled week days.
      *
      * \param aDays Set of enabled week days.
      */
-    void setDays(const DaySet &aDays);
+    void setDays(Days aDays);
 
     /*! \brief Gets the exact time set in sync schedule.
      *
@@ -196,13 +205,13 @@ public:
      *
      * \return Set of days enabled for rush hours.
      */
-    DaySet rushDays() const;
+    Days rushDays() const;
 
     /*! \brief Sets days enabled for rush hours.
      *
      * \param aDays Enabled days for rush hours.
      */
-    void setRushDays(const DaySet &aDays);
+    void setRushDays(Days aDays);
 
     /*! \brief Gets begin time of rush hours.
      *

--- a/libbuteosyncfw/profile/SyncSchedule_p.h
+++ b/libbuteosyncfw/profile/SyncSchedule_p.h
@@ -27,6 +27,8 @@
 #include <QDateTime>
 #include <QString>
 
+#include "SyncSchedule.h"
+
 namespace Buteo {
 
 //! Private implementation class for SyncSchedule.
@@ -43,32 +45,40 @@ public:
      */
     SyncSchedulePrivate(const SyncSchedulePrivate &aSource);
 
+    /*! \brief Tell if aDays contains aDay.
+     *
+     * \param aDays A set of days.
+     * \param aDay A given day in Qt convention of Qt::DayOfWeek.
+     * \return true if aDay is within aDays.
+     */
+    static bool daysMatch(SyncSchedule::Days aDays, int aDay);
+
     /*! \brief Parses week day numbers from a string.
      *
      * \param aDays String containing the week day numbers.
-     * \return Set of week day numbers.
+     * \return Set of week days.
      */
-    DaySet parseDays(const QString &aDays) const;
+    SyncSchedule::Days parseDays(const QString &aDays) const;
 
     /*! \brief Creates a string from a set of week day numbers.
      *
-     * \param aDays Set of week day numbers.
-     * \return String of week day numbers.
+     * \param aDays Set of week days.
+     * \return String of week day represented by their numbers (Monday = 1).
      */
-    QString createDays(const DaySet &aDays) const;
+    QString createDays(SyncSchedule::Days aDays) const;
 
     /*! \brief Adjusts given date to be in the set of given week days.
      *
      * Day is increased until the week day is contained in the given set of
      * week day numbers.
      * \param aTime Date/time to adjust.
-     * \param aDays Set of enabled week day numbers.
+     * \param aDays Set of enabled week days.
      * \return Was day adjusted to a valid day. If the week day was already in
      *  the set of given week days, this function returns false. If the day
      *  set does not contain any valid days, this function sets aTime to null
      *  object and returns false.
      */
-    bool adjustDate(QDateTime &aTime, const DaySet &aDays) const;
+    bool adjustDate(QDateTime &aTime, SyncSchedule::Days aDays) const;
 
     /*! \brief Checks if the given date/time is inside rush hours.
      *
@@ -77,8 +87,8 @@ public:
      */
     bool isRush(const QDateTime &aTime) const;
 
-    //! Number of Days before the next sync starts
-    DaySet iDays;
+    //! Days for the sync
+    SyncSchedule::Days iDays;
 
     //! Sync Time
     QTime iTime;
@@ -94,7 +104,7 @@ public:
     // ============ RUSH HOUR SETTINGS ===========
 
     //! indicates the schedule for rush hour - days
-    DaySet iRushDays;
+    SyncSchedule::Days iRushDays;
 
     //! indicates the schedule for rush hour start
     QTime iRushBegin;

--- a/msyncd/AccountsHelper.cpp
+++ b/msyncd/AccountsHelper.cpp
@@ -213,23 +213,17 @@ void AccountsHelper::setSyncSchedule(SyncProfile *syncProfile, Accounts::Account
         syncSchedule.setRushInterval(scheduleInterval);
         LOG_DEBUG ("Sync Rush Interval :" << scheduleInterval);
 
-        int map = account->valueAsInt (Buteo::SYNC_SCHEDULE_PEAK_DAYS_KEY_INT);
-        LOG_DEBUG ("Sync Days :" << account->valueAsInt (Buteo::SYNC_SCHEDULE_PEAK_DAYS_KEY_INT));
-        Buteo::DaySet rdays;
-        Buteo::DaySet days;
-        int lastDay = Qt::Sunday;
-        while (lastDay > 0) {
-            int val = 0;
-            val |= (1 << (lastDay - 1));
-            days.insert(lastDay);
-            if ((val & map)) {
-                rdays.insert(lastDay);
-                LOG_DEBUG ("Day :" << lastDay);
-            }
-            --lastDay;
-        }
-        syncSchedule.setRushDays(rdays);
-        syncSchedule.setDays(days);
+        syncSchedule.setDays(Buteo::SyncSchedule::Days()
+                             | Buteo::SyncSchedule::Monday
+                             | Buteo::SyncSchedule::Tuesday
+                             | Buteo::SyncSchedule::Wednesday
+                             | Buteo::SyncSchedule::Thursday
+                             | Buteo::SyncSchedule::Friday
+                             | Buteo::SyncSchedule::Saturday
+                             | Buteo::SyncSchedule::Sunday);
+        syncSchedule.setRushDays(Buteo::SyncSchedule::Days(account->valueAsInt(Buteo::SYNC_SCHEDULE_PEAK_DAYS_KEY_INT)));
+        LOG_DEBUG ("Sync Days :" << syncSchedule.rushDays());
+
         account->endGroup();
         syncProfile->setSyncSchedule (syncSchedule);
     }

--- a/rpm/buteo-syncfw-qt5.spec
+++ b/rpm/buteo-syncfw-qt5.spec
@@ -1,5 +1,5 @@
 Name:    buteo-syncfw-qt5
-Version: 0.10.0
+Version: 0.10.8
 Release: 1
 Summary: Synchronization backend
 URL:     https://git.sailfishos.org/mer-core/buteo-syncfw/

--- a/unittests/tests/syncprofiletests/SyncProfileTest/SyncProfileTest.cpp
+++ b/unittests/tests/syncprofiletests/SyncProfileTest/SyncProfileTest.cpp
@@ -191,10 +191,14 @@ void SyncProfileTest::testNextSyncTime()
     SyncSchedule s;
     const unsigned INTERVAL = 15;
     s.setInterval(INTERVAL);
-    DaySet days;
-    days << Qt::Monday << Qt::Tuesday << Qt::Wednesday << Qt::Thursday <<
-         Qt::Friday << Qt::Saturday << Qt::Sunday;
-    s.setDays(days);
+    s.setDays(Buteo::SyncSchedule::Days()
+              | Buteo::SyncSchedule::Monday
+              | Buteo::SyncSchedule::Tuesday
+              | Buteo::SyncSchedule::Wednesday
+              | Buteo::SyncSchedule::Thursday
+              | Buteo::SyncSchedule::Friday
+              | Buteo::SyncSchedule::Saturday
+              | Buteo::SyncSchedule::Sunday);
     s.setScheduleEnabled(true);
     p.setSyncSchedule(s);
     QDateTime nextSync = p.nextSyncTime(p.lastSyncTime());


### PR DESCRIPTION
…es. Contributes to JB#49486

@pvuorela , as discussed this morning, here is a PR that changes the API of SyncSchedule to use a QFlags instead of a QSet.