### PR TITLE
[buteo-syncfw] Properly initialize plugin service on cleanup.

### DIFF
--- a/oopp-runner/PluginServiceObj.cpp
+++ b/oopp-runner/PluginServiceObj.cpp
@@ -163,7 +163,7 @@ bool PluginServiceObj::cleanUp()
     FUNCTION_CALL_TRACE(lcButeoTrace);
 
     if (!iPlugin) {
-        initializePlugin();
+        iPlugin = initializePlugin();
         if (!iPlugin) {
             qCWarning(lcButeoPlugin) << "PluginServiceObj::cleanUp(): unable to initialize plugin" ;
             return false;


### PR DESCRIPTION
This may solve the account deletion issue in 4.2.0 where the cleanup is not called for plugins, leaving the calendar after account deletion for instance.

See https://forum.sailfishos.org/t/release-notes-verla-4-2-0/7092/93 and https://forum.sailfishos.org/t/release-notes-verla-4-2-0/7092/22 for user reports.

@pvuorela, @chriadam and @blammit what do you think ?