### PR TITLE
[packaging] BuildRequire systemd via pkgconfig. JB#55010

### DIFF
--- a/rpm/buteo-syncfw-qt5.spec
+++ b/rpm/buteo-syncfw-qt5.spec
@@ -21,7 +21,7 @@ BuildRequires: pkgconfig(qt5-boostable)
 BuildRequires: pkgconfig(keepalive)
 BuildRequires: pkgconfig(gio-2.0)
 BuildRequires: pkgconfig(mce-qt5) >= 1.1.0
-BuildRequires: systemd
+BuildRequires: pkgconfig(systemd)
 Requires: mapplauncherd-qt5
 Requires: glib2
 Requires: libmce-qt5 >= 1.1.0


### PR DESCRIPTION
This allows to pick systemd-mini inside the builder instead of full
systemd.