### PR TITLE
[buteo-syncfw] Make the log messages invocable from QML.

### DIFF
--- a/libbuteosyncfw/profile/TargetResults.h
+++ b/libbuteosyncfw/profile/TargetResults.h
@@ -202,7 +202,7 @@ public:
      * \param aUid A UID as returned by localDetails().
      * \return A message stored in the log related to this particular item.
      */
-    QString localMessage(const QString &aUid) const;
+    Q_INVOKABLE QString localMessage(const QString &aUid) const;
 
     /*! \brief Gets the details, if any for changes done remote during a sync process.
      *
@@ -221,7 +221,7 @@ public:
      * \param aUid A UID as returned by remoteDetails().
      * \return A message stored in the log related to this particular item.
      */
-    QString remoteMessage(const QString &aUid) const;
+    Q_INVOKABLE QString remoteMessage(const QString &aUid) const;
 
 private:
 

--- a/rpm/buteo-syncfw-qt5.spec
+++ b/rpm/buteo-syncfw-qt5.spec
@@ -1,5 +1,5 @@
 Name:    buteo-syncfw-qt5
-Version: 0.10.13
+Version: 0.10.15
 Release: 1
 Summary: Synchronization backend
 URL:     https://github.com/sailfishos/buteo-syncfw/


### PR DESCRIPTION
Pieces are coming together to get the log of Buteo sync process to the user.

Now that the CalDAV plugin is logging errors, I'm trying to bring them to the user. So that's why it's better if this method in TargetResult (fetching the error message in the log for a given item) should be invocable.

@chriadam do you agree ?