### PR TITLE
Fix signal connections for bluez5

### DIFF
--- a/libbuteosyncfw/common/BtCommon.h
+++ b/libbuteosyncfw/common/BtCommon.h
@@ -28,13 +28,13 @@ namespace BT {
 
 } // namespace BT
 
+} // namespace Buteo
+
 typedef QMap<QString,QVariantMap> InterfacesMap;
 typedef QMap<QDBusObjectPath,InterfacesMap> ObjectsMap;
 
-} // namespace Buteo
-
-Q_DECLARE_METATYPE(Buteo::InterfacesMap)
-Q_DECLARE_METATYPE(Buteo::ObjectsMap)
+Q_DECLARE_METATYPE(InterfacesMap)
+Q_DECLARE_METATYPE(ObjectsMap)
 
 #endif /* HAVE_BLUEZ_5 */
 

--- a/libbuteosyncfw/common/TransportTracker.cpp
+++ b/libbuteosyncfw/common/TransportTracker.cpp
@@ -73,7 +73,7 @@ TransportTracker::TransportTracker(QObject *aParent) :
                      BT::BLUEZ_MANAGER_INTERFACE,
                      BT::INTERFACESADDED,
                      this,
-                     SLOT(onBtInterfacesAdded(QDBusObjectPath, InterfacesMap)))) {
+                     SLOT(onBtInterfacesAdded(const QDBusObjectPath &, const InterfacesMap &)))) {
         qCWarning(lcButeoCore) << "Failed to connect InterfacesAdded signal";
     }
 
@@ -82,7 +82,7 @@ TransportTracker::TransportTracker(QObject *aParent) :
                      BT::BLUEZ_MANAGER_INTERFACE,
                      BT::INTERFACESREMOVED,
                      this,
-                     SLOT(onBtInterfacesRemoved(QDBusObjectPath, QStringList)))) {
+                     SLOT(onBtInterfacesRemoved(const QDBusObjectPath &, const QStringList &)))) {
         qCWarning(lcButeoCore) << "Failed to connect InterfacesRemoved signal";
     }
 
@@ -93,7 +93,7 @@ TransportTracker::TransportTracker(QObject *aParent) :
                 BT::BLUEZ_PROPERTIES_INTERFACE,
                 BT::PROPERTIESCHANGED,
                 this,
-                SLOT(onBtStateChanged(QString, QVariantMap, QStringList)))) {
+                SLOT(onBtStateChanged(const QString &, const QVariantMap &, const QStringList &)))) {
             qCWarning(lcButeoCore) << "Failed to connect PropertiesChanged signal";
         }
         // Set the bluetooth state to on
@@ -136,14 +136,14 @@ void TransportTracker::onUsbStateChanged(bool aConnected)
 }
 
 #ifdef HAVE_BLUEZ_5
-void TransportTracker::onBtStateChanged(QString interface, QVariantMap changed, QStringList invalidated)
+void TransportTracker::onBtStateChanged(const QString &interface, const QVariantMap &changed, const QStringList &invalidated)
 {
     FUNCTION_CALL_TRACE(lcButeoTrace);
 
     Q_UNUSED(invalidated);
 
     if (interface == BT::BLUEZ_ADAPTER_INTERFACE) {
-        for (QVariantMap::iterator i = changed.begin(); i != changed.end(); ++i) {
+        for (QVariantMap::const_iterator i = changed.begin(); i != changed.end(); ++i) {
             if (i.key() == "Powered") {
                 bool btOn = i.value().toBool();
                 qCInfo(lcButeoCore) << "BT power state " << btOn;
@@ -153,7 +153,7 @@ void TransportTracker::onBtStateChanged(QString interface, QVariantMap changed, 
     }
 }
 
-void TransportTracker::onBtInterfacesAdded(const QDBusObjectPath &path, const InterfacesMap interfaces)
+void TransportTracker::onBtInterfacesAdded(const QDBusObjectPath &path, const InterfacesMap &interfaces)
 {
     FUNCTION_CALL_TRACE(lcButeoTrace);
 
@@ -177,7 +177,7 @@ void TransportTracker::onBtInterfacesAdded(const QDBusObjectPath &path, const In
                     BT::BLUEZ_PROPERTIES_INTERFACE,
                     BT::PROPERTIESCHANGED,
                     this,
-                    SLOT(onBtStateChanged(QString, QVariantMap, QStringList)))) {
+                    SLOT(onBtStateChanged(const QString &, const QVariantMap &, const QStringList &)))) {
                 qCWarning(lcButeoCore) << "Failed to connect PropertiesChanged signal";
 
             }
@@ -190,7 +190,7 @@ void TransportTracker::onBtInterfacesAdded(const QDBusObjectPath &path, const In
     }
 }
 
-void TransportTracker::onBtInterfacesRemoved(const QDBusObjectPath &path, const QStringList interfaces)
+void TransportTracker::onBtInterfacesRemoved(const QDBusObjectPath &path, const QStringList &interfaces)
 {
     FUNCTION_CALL_TRACE(lcButeoTrace);
 
@@ -207,7 +207,7 @@ void TransportTracker::onBtInterfacesRemoved(const QDBusObjectPath &path, const 
                     BT::BLUEZ_PROPERTIES_INTERFACE,
                     BT::PROPERTIESCHANGED,
                     this,
-                    SLOT(onBtStateChanged(QString,QVariantMap,QStringList)))) {
+                    SLOT(onBtStateChanged(const QString &, const QVariantMap &, const QStringList &)))) {
                 qCWarning(lcButeoCore) << "Failed to disconnect PropertiesChanged signal";
             } else {
                 qCDebug(lcButeoCore) << "'org.bluez.Adapter1' interface removed from " << path.path();

--- a/libbuteosyncfw/common/TransportTracker.h
+++ b/libbuteosyncfw/common/TransportTracker.h
@@ -97,11 +97,11 @@ private slots:
     void onUsbStateChanged(bool aConnected);
 
 #ifdef HAVE_BLUEZ_5
-    void onBtStateChanged(QString interface, QVariantMap changed, QStringList invalidated);
+    void onBtStateChanged(const QString &interface, const QVariantMap &changed, const QStringList &invalidated);
 
-    void onBtInterfacesAdded(const QDBusObjectPath &path, const InterfacesMap interfaces);
+    void onBtInterfacesAdded(const QDBusObjectPath &path, const InterfacesMap &interfaces);
 
-    void onBtInterfacesRemoved(const QDBusObjectPath &path, const QStringList interfaces);
+    void onBtInterfacesRemoved(const QDBusObjectPath &path, const QStringList &interfaces);
 #endif
 
     void onInternetStateChanged(bool aConnected, Sync::InternetConnectionType aType);


### PR DESCRIPTION
1. Fix for "Failed to connect InterfacesAdded signal" when compiled with HAVE_BLUEZ_5 
2. use static for the slot values in onBtStateChanged, onBtInterfacesAdded and onBtInterfacesRemoved