### PR TITLE
[buteo-syncfw] Fix file existence test in one shot.

### DIFF
--- a/rpm/move-buteo-config.sh
+++ b/rpm/move-buteo-config.sh
@@ -1,6 +1,6 @@
 #/bin/sh
 # move the msyncs configs, logs etc from .cache to .local
-if [ ! -a $HOME/.local/share/system/privileged/msyncd/cache_dir_migrated ]; then
+if [ ! -f $HOME/.local/share/system/privileged/msyncd/cache_dir_migrated ]; then
   if [ -d $HOME/.cache/msyncd ]; then
     if [ -d $HOME/.local/share/system/privileged/msyncd/sync ]; then
       # msyncd probably restarted before this oneshot got executed. just move basic known content


### PR DESCRIPTION
Not sure this is a smart change, but after upgrading Buteo to the latest, the oneshot didn't effectively worked and I was still with my profiles and logs in `~/.cache/`. I then try to run the oneshot by hand an I got a `ash` shell error "operand unknown" or something like that.

From my knowledge of `test`, `-a` is a binary operator for AND. @pvuorela, was it intentional ?