### PR TITLE
[buteo-syncfw] Create doc/html before building. Fixes JB#60392

### DIFF
--- a/doc/doc.pri
+++ b/doc/doc.pri
@@ -9,7 +9,7 @@ doc.depends = FORCE
 
 QMAKE_CLEAN += $${PWD}/html/* $${PWD}/buteo-syncfw.tag
 
-htmldocs.files = $${PWD}/html/
+htmldocs.files = $${PWD}/html/*
 htmldocs.path = /usr/share/doc/buteo-syncfw-doc/
 htmldocs.CONFIG += no_check_exist
 


### PR DESCRIPTION
If the directory does not exist, qmake assumes it's a file and uses wrong install method.