### PR TITLE
Expose msyncd interface into QML objects

### DIFF
--- a/declarative/declarative.pro
+++ b/declarative/declarative.pro
@@ -14,12 +14,15 @@ SOURCES += plugin.cpp \
     syncresultmodelbase.cpp \
     syncresultmodel.cpp \
     multisyncresultmodel.cpp \
-    syncprofilewatcher.cpp
+    syncprofilewatcher.cpp \
+    syncmanager.cpp
 
 HEADERS += syncresultmodelbase.h \
     syncresultmodel.h \
     multisyncresultmodel.h \
-    syncprofilewatcher.h
+    syncprofilewatcher.h \
+    profileentry.h \
+    syncmanager.h
 
 OTHER_FILES += qmldir
 

--- a/declarative/multisyncresultmodel.cpp
+++ b/declarative/multisyncresultmodel.cpp
@@ -44,7 +44,7 @@ MultiSyncResultModel::MultiSyncResultModel(QObject *parent)
     }
     sort();
     sortFilterList();
-    connect(&mSyncClient, &SyncClientInterface::profileChanged,
+    connect(mSyncClient.data(), &SyncClientInterface::profileChanged,
             this, &MultiSyncResultModel::onProfileChanged);
 }
 

--- a/declarative/multisyncresultmodel.cpp
+++ b/declarative/multisyncresultmodel.cpp
@@ -27,11 +27,6 @@
 
 using namespace Buteo;
 
-bool ProfileEntry::operator<(const struct ProfileEntry &other)
-{
-    return label < other.label;
-}
-
 MultiSyncResultModel::MultiSyncResultModel(QObject *parent)
     : SyncResultModelBase(parent)
     , mSortOption(MultiSyncResultModel::ByDate)

--- a/declarative/multisyncresultmodel.h
+++ b/declarative/multisyncresultmodel.h
@@ -24,19 +24,8 @@
 #ifndef MULTISYNCRESULTMODEL_H
 #define MULTISYNCRESULTMODEL_H
 
-#include <syncresultmodelbase.h>
-
-struct ProfileEntry {
-    Q_GADGET
-    Q_PROPERTY(QString id MEMBER id)
-    Q_PROPERTY(QString label MEMBER label)
-    Q_PROPERTY(QString clientName MEMBER clientName)
-public:
-    QString id;
-    QString label;
-    QString clientName;
-    bool operator<(const struct ProfileEntry &other);
-};
+#include "syncresultmodelbase.h"
+#include "profileentry.h"
 
 class MultiSyncResultModel: public SyncResultModelBase
 {

--- a/declarative/plugin.cpp
+++ b/declarative/plugin.cpp
@@ -28,6 +28,7 @@
 
 #include "profile/SyncResults.h"
 #include "profile/SyncSchedule.h"
+#include "syncmanager.h"
 #include "syncresultmodel.h"
 #include "multisyncresultmodel.h"
 #include "syncprofilewatcher.h"
@@ -53,6 +54,9 @@ public:
     {
         Q_ASSERT(uri == QLatin1String("Buteo.Profiles"));
 
+        qmlRegisterType<SyncManager>(uri, 0, 1, "SyncManager");
+        qmlRegisterUncreatableType<ProfileFilter>(uri, 0, 1, "ProfileFilter",
+                                                  "ProfileFilter is used as a group property of SyncManager");
         qmlRegisterType<SyncProfileWatcher>(uri, 0, 1, "SyncProfileWatcher");
         qRegisterMetaType<Buteo::SyncSchedule>("SyncSchedule");
         qmlRegisterUncreatableType<Buteo::SyncSchedule>(uri, 0, 1, "SyncSchedule",

--- a/declarative/profileentry.h
+++ b/declarative/profileentry.h
@@ -1,0 +1,44 @@
+/*
+ * This file is part of buteo-syncfw package
+ *
+ * Copyright (C) 2024 Damien Caliste.
+ *
+ * Contact: Damien Caliste <dcaliste@free.fr>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * version 2.1 as published by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ *
+ */
+
+#ifndef PROFILEENTRY_H
+#define PROFILEENTRY_H
+
+#include <QObject>
+
+struct ProfileEntry {
+    Q_GADGET
+    Q_PROPERTY(QString id MEMBER id)
+    Q_PROPERTY(QString label MEMBER label)
+    Q_PROPERTY(QString clientName MEMBER clientName)
+public:
+    QString id;
+    QString label;
+    QString clientName;
+    bool operator<(const struct ProfileEntry &other)
+    {
+        return label < other.label;
+    }
+};
+
+#endif

--- a/declarative/syncmanager.cpp
+++ b/declarative/syncmanager.cpp
@@ -1,0 +1,310 @@
+/*
+ * This file is part of buteo-syncfw package
+ *
+ * Copyright (C) 2024 Damien Caliste.
+ *
+ * Contact: Damien Caliste <dcaliste@free.fr>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * version 2.1 as published by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ *
+ */
+
+#include "syncmanager.h"
+
+#include <ProfileManager.h>
+#include <SyncCommonDefs.h>
+#include <ProfileEngineDefs.h>
+
+#include <QDBusPendingCallWatcher>
+#include <QDBusPendingReply>
+#include <QDebug>
+
+using namespace Buteo;
+
+SyncManager::SyncManager(QObject *parent)
+    : QObject(parent)
+    , mSyncClient(SyncClientInterface::sharedInstance())
+    , mFilterBy(new ProfileFilter(this))
+{
+    connect(mSyncClient.data(), &SyncClientInterface::isValidChanged,
+            this, &SyncManager::serviceAvailableChanged);
+    connect(mSyncClient.data(), &SyncClientInterface::syncStatus,
+            this, &SyncManager::onSyncStatusChanged);
+    connect(mSyncClient.data(), &SyncClientInterface::profileChanged,
+            this, &SyncManager::onProfileChanged);
+
+    connect(mFilterBy, &ProfileFilter::updated,
+            this, &SyncManager::requestSyncProfiles);
+
+    requestRunningSyncList();
+}
+
+SyncManager::~SyncManager()
+{
+}
+
+void SyncManager::classBegin()
+{
+}
+
+void SyncManager::componentComplete()
+{
+    mComponentCompleted = true;
+    requestSyncProfiles();
+}
+
+bool SyncManager::serviceAvailable() const
+{
+    return mSyncClient->isValid();
+}
+
+bool SyncManager::synchronizing() const
+{
+    for (const ProfileEntry &entry : mProfiles) {
+        if (mSyncingProfiles.contains(entry.id))
+            return true;
+    }
+    return false;
+}
+
+void SyncManager::onSyncStatusChanged(QString aProfileId, int aStatus,
+                                      QString aMessage, int aStatusDetails)
+{
+    Q_UNUSED(aMessage);
+    Q_UNUSED(aStatusDetails);
+
+    bool syncInProgress = synchronizing();
+    if (static_cast<Sync::SyncStatus>(aStatus) < Sync::SYNC_ERROR)
+        mSyncingProfiles.insert(aProfileId);
+    else
+        mSyncingProfiles.remove(aProfileId);
+
+    if (syncInProgress != synchronizing())
+        emit synchronizingChanged();
+}
+
+void SyncManager::requestRunningSyncList()
+{
+    connect(mSyncClient->requestRunningSyncList(this),
+            &QDBusPendingCallWatcher::finished,
+            [this] (QDBusPendingCallWatcher *call) {
+                QDBusPendingReply<QStringList> reply = *call;
+                if (reply.isError()) {
+                    qWarning() << "cannot get running sync list:" << reply.error().message();
+                } else {
+                    bool syncInProgress = synchronizing();
+                    mSyncingProfiles.clear();
+                    for (const QString profileId : reply.value()) {
+                        mSyncingProfiles.insert(profileId);
+                    }
+                    if (syncInProgress != synchronizing()) {
+                        emit synchronizingChanged();
+                    }
+                }
+                call->deleteLater();
+            });
+}
+
+void SyncManager::onProfileChanged(QString aProfileName, int aChangeType,
+                                   QString aProfileAsXml)
+{
+    Q_UNUSED(aProfileAsXml);
+    ProfileManager::ProfileChangeType change = static_cast<ProfileManager::ProfileChangeType>(aChangeType);
+
+    bool changed = false;
+    if (change == ProfileManager::PROFILE_MODIFIED
+        || change == ProfileManager::PROFILE_REMOVED) {
+        mProfiles.erase(std::remove_if(mProfiles.begin(), mProfiles.end(),
+                                       [aProfileName] (const ProfileEntry &entry)
+                                       {return entry.id == aProfileName;}),
+                        mProfiles.end());
+        changed = true;
+    }
+    if (change == ProfileManager::PROFILE_MODIFIED
+        || change == ProfileManager::PROFILE_ADDED) {
+        Profile *profile = ProfileManager::profileFromXml(aProfileAsXml);
+        if (profile && addProfile(*profile)) {
+            std::sort(mProfiles.begin(), mProfiles.end());
+            changed = true;
+        }
+        delete profile;
+    }
+    if (changed) {
+        emit profilesChanged();
+        emit synchronizingChanged();
+    }
+}
+
+void SyncManager::requestSyncProfiles()
+{
+    if (!mComponentCompleted)
+        return;
+
+    QDBusPendingCallWatcher *request;
+    if (mFilterBy->isValid()) {
+        request = mSyncClient->requestSyncProfilesByKey(mFilterBy->key,
+                                                        mFilterBy->value,
+                                                        this);
+    } else if (!mFilterByAccount.isEmpty()) {
+        request = mSyncClient->requestSyncProfilesByKey(KEY_ACCOUNT_ID,
+                                                        mFilterByAccount,
+                                                        this);
+    } else if (mFilterHidden) {
+        request = mSyncClient->requestAllVisibleSyncProfiles(this);
+    } else {
+        request = mSyncClient->requestProfilesByType(Profile::TYPE_SYNC, this);
+    }
+    connect(request, &QDBusPendingCallWatcher::finished,
+            [this] (QDBusPendingCallWatcher *call) {
+                QDBusPendingReply<QStringList> reply = *call;
+                if (reply.isError()) {
+                    qWarning() << "cannot list profiles:" << reply.error().message();
+                } else {
+                    setProfilesFromXml(reply.value());
+                }
+                call->deleteLater();
+            });
+}
+
+QVariantList SyncManager::profiles() const
+{
+    QVariantList list;
+    for (const ProfileEntry &entry : mProfiles) {
+        list << QVariant::fromValue(entry);
+    }
+    return list;
+}
+
+void SyncManager::setProfilesFromXml(const QStringList &profiles)
+{
+    bool changed = !mProfiles.isEmpty();
+    mProfiles.clear();
+    for (const QString profileAsXml : profiles) {
+        Profile *profile = ProfileManager::profileFromXml(profileAsXml);
+        if (profile && addProfile(*profile)) {
+            changed = true;
+        }
+        delete profile;
+    }
+    if (changed) {
+        std::sort(mProfiles.begin(), mProfiles.end());
+        emit profilesChanged();
+        emit synchronizingChanged();
+    }
+}
+
+bool SyncManager::addProfile(const Profile &profile)
+{
+    if (profile.type() != Profile::TYPE_SYNC) {
+        return false;
+    }
+    if (mFilterDisabled && !profile.isEnabled()) {
+        return false;
+    }
+    if (mFilterHidden && profile.isHidden()) {
+        return false;
+    }
+    if (!mFilterByAccount.isEmpty() && profile.key(KEY_ACCOUNT_ID) != mFilterByAccount) {
+        return false;
+    }
+    const Profile *client = static_cast<const SyncProfile*>(&profile)->clientProfile();
+    mProfiles << ProfileEntry{profile.name(),
+            profile.displayname(), client ? client->name() : QString()};
+    return true;
+}
+
+bool SyncManager::filterDisabled() const
+{
+    return mFilterDisabled;
+}
+
+bool SyncManager::filterHidden() const
+{
+    return mFilterHidden;
+}
+
+QString SyncManager::filterByAccount() const
+{
+    return mFilterByAccount;
+}
+
+ProfileFilter* SyncManager::filterBy() const
+{
+    return mFilterBy;
+}
+
+void SyncManager::setFilterDisabled(bool value)
+{
+    if (value == mFilterDisabled)
+        return;
+
+    mFilterDisabled = value;
+    emit filterDisabledChanged();
+
+    requestSyncProfiles();
+}
+
+void SyncManager::setFilterHidden(bool value)
+{
+    if (value == mFilterHidden)
+        return;
+
+    mFilterHidden = value;
+    emit filterHiddenChanged();
+
+    requestSyncProfiles();
+}
+
+void SyncManager::setFilterByAccount(const QString &accountId)
+{
+    if (accountId == mFilterByAccount)
+        return;
+
+    mFilterByAccount = accountId;
+    emit filterByAccountChanged();
+
+    requestSyncProfiles();
+}
+
+void SyncManager::synchronize()
+{
+    for (const ProfileEntry &entry : mProfiles) {
+        connect(mSyncClient->requestSync(entry.id, this),
+                &QDBusPendingCallWatcher::finished,
+                [this, entry] (QDBusPendingCallWatcher *call) {
+                    QDBusPendingReply<bool> reply = *call;
+                    if (reply.isError() || !reply.value()) {
+                        qWarning() << "cannot start sync for" << entry.id
+                                   << ":" << (reply.isError() ? reply.error().message() : "no such profile");
+                        mSyncingProfiles.remove(entry.id);
+                        emit synchronizingChanged();
+                    }
+                    call->deleteLater();
+                });
+        mSyncingProfiles.insert(entry.id);
+    }
+    if (!mProfiles.isEmpty())
+        emit synchronizingChanged();
+}
+
+void SyncManager::abort()
+{
+    for (const ProfileEntry &entry : mProfiles) {
+        mSyncClient->abortSync(entry.id);
+        mSyncingProfiles.remove(entry.id);
+    }
+    if (!mProfiles.isEmpty())
+        emit synchronizingChanged();
+}

--- a/declarative/syncmanager.h
+++ b/declarative/syncmanager.h
@@ -1,0 +1,126 @@
+/*
+ * This file is part of buteo-syncfw package
+ *
+ * Copyright (C) 2024 Damien Caliste.
+ *
+ * Contact: Damien Caliste <dcaliste@free.fr>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * version 2.1 as published by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ *
+ */
+
+#ifndef SYNCMANAGER_H
+#define SYNCMANAGER_H
+
+#include <QObject>
+#include <QSet>
+#include <QQmlParserStatus>
+
+#include "clientfw/SyncClientInterface.h"
+
+#include "profileentry.h"
+
+using namespace Buteo;
+
+class ProfileFilter: public QObject {
+    Q_OBJECT
+    Q_PROPERTY(QString key MEMBER key NOTIFY updated)
+    Q_PROPERTY(QString value MEMBER value NOTIFY updated)
+public:
+    ProfileFilter(QObject *parent = nullptr)
+        : QObject(parent)
+    {
+    }
+    bool operator==(const struct ProfileFilter &other) const
+    {
+        return key == other.key && value == other.value;
+    }
+    bool isValid() const
+    {
+        return !key.isEmpty() && !value.isEmpty();
+    }
+    QString key;
+    QString value;
+signals:
+    void updated();
+};
+
+class Q_DECL_EXPORT SyncManager: public QObject, public QQmlParserStatus
+{
+    Q_OBJECT
+    Q_INTERFACES(QQmlParserStatus)
+
+    Q_PROPERTY(bool serviceAvailable READ serviceAvailable NOTIFY serviceAvailableChanged)
+    Q_PROPERTY(bool synchronizing READ synchronizing NOTIFY synchronizingChanged)
+
+    Q_PROPERTY(bool filterDisabled READ filterDisabled WRITE setFilterDisabled NOTIFY filterDisabledChanged)
+    Q_PROPERTY(bool filterHidden READ filterHidden WRITE setFilterHidden NOTIFY filterHiddenChanged)
+    Q_PROPERTY(QString filterByAccount READ filterByAccount WRITE setFilterByAccount NOTIFY filterByAccountChanged)
+    Q_PROPERTY(ProfileFilter* filterBy READ filterBy CONSTANT)
+    Q_PROPERTY(QVariantList profiles READ profiles NOTIFY profilesChanged)
+
+public:
+    SyncManager(QObject *parent = nullptr);
+    ~SyncManager();
+
+    void classBegin() override;
+    void componentComplete() override;
+
+    bool serviceAvailable() const;
+    bool synchronizing() const;
+
+    bool filterDisabled() const;
+    bool filterHidden() const;
+    QString filterByAccount() const;
+    ProfileFilter* filterBy() const;
+    QVariantList profiles() const;
+
+    void setFilterDisabled(bool value);
+    void setFilterHidden(bool value);
+    void setFilterByAccount(const QString &accountId);
+
+    Q_INVOKABLE void synchronize();
+    Q_INVOKABLE void abort();
+
+signals:
+    void serviceAvailableChanged();
+    void synchronizingChanged();
+    void filterDisabledChanged();
+    void filterHiddenChanged();
+    void filterByAccountChanged();
+    void profilesChanged();
+
+private:
+    void requestSyncProfiles();
+    void onProfileChanged(QString aProfileName, int aChangeType,
+                          QString aProfileAsXml);
+    void requestRunningSyncList();
+    void onSyncStatusChanged(QString aProfileId, int aStatus,
+                             QString aMessage, int aStatusDetails);
+    bool addProfile(const Profile &profile);
+    void setProfilesFromXml(const QStringList &profiles);
+
+    QSharedPointer<SyncClientInterface> mSyncClient;
+    QSet<QString> mSyncingProfiles;
+
+    bool mComponentCompleted = false;
+    bool mFilterDisabled = true;
+    bool mFilterHidden = false;
+    QString mFilterByAccount;
+    ProfileFilter *mFilterBy;
+    QList<ProfileEntry> mProfiles;
+};
+
+#endif

--- a/declarative/syncprofilewatcher.cpp
+++ b/declarative/syncprofilewatcher.cpp
@@ -28,13 +28,16 @@
 using namespace Buteo;
 
 SyncProfileWatcher::SyncProfileWatcher(QObject *parent)
-    : QObject(parent), mSyncProfile(nullptr), mSyncStatus(Sync::SYNC_DONE)
+    : QObject(parent)
+    , mSyncClient(SyncClientInterface::sharedInstance())
+    , mSyncProfile(nullptr)
+    , mSyncStatus(Sync::SYNC_DONE)
 {
     connect(&mManager, &ProfileManager::signalProfileChanged,
             this, &SyncProfileWatcher::onProfileChanged);
-    connect(&mSyncClient, &SyncClientInterface::profileChanged,
+    connect(mSyncClient.data(), &SyncClientInterface::profileChanged,
             this, &SyncProfileWatcher::onProfileChanged);
-    connect(&mSyncClient, &SyncClientInterface::syncStatus,
+    connect(mSyncClient.data(), &SyncClientInterface::syncStatus,
             this, &SyncProfileWatcher::onSyncStatus);
 }
 
@@ -142,14 +145,14 @@ Sync::SyncStatus SyncProfileWatcher::syncStatus() const
 void SyncProfileWatcher::startSync() const
 {
     if (mSyncProfile) {
-        mSyncClient.startSync(mSyncProfile->name());
+        mSyncClient->startSync(mSyncProfile->name());
     }
 }
 
 void SyncProfileWatcher::abortSync() const
 {
     if (mSyncProfile) {
-        mSyncClient.abortSync(mSyncProfile->name());
+        mSyncClient->abortSync(mSyncProfile->name());
     }
 }
 

--- a/declarative/syncprofilewatcher.cpp
+++ b/declarative/syncprofilewatcher.cpp
@@ -142,6 +142,11 @@ Sync::SyncStatus SyncProfileWatcher::syncStatus() const
     return mSyncStatus;
 }
 
+bool SyncProfileWatcher::synchronizing() const
+{
+    return mSyncStatus < Sync::SYNC_ERROR;
+}
+
 void SyncProfileWatcher::startSync() const
 {
     if (mSyncProfile) {

--- a/declarative/syncprofilewatcher.h
+++ b/declarative/syncprofilewatcher.h
@@ -43,6 +43,7 @@ class Q_DECL_EXPORT SyncProfileWatcher: public QObject
     Q_PROPERTY(SyncSchedule schedule READ schedule NOTIFY scheduleChanged)
     Q_PROPERTY(QVariantMap keys READ keys NOTIFY keysChanged)
     Q_PROPERTY(Sync::SyncStatus syncStatus READ syncStatus NOTIFY syncStatusChanged)
+    Q_PROPERTY(bool synchronizing READ synchronizing NOTIFY syncStatusChanged)
 
 public:
     SyncProfileWatcher(QObject *parent = nullptr);
@@ -62,6 +63,8 @@ public:
     QVariantMap keys() const;
 
     Sync::SyncStatus syncStatus() const;
+
+    bool synchronizing() const;
 
     Q_INVOKABLE void startSync() const;
     Q_INVOKABLE void abortSync() const;

--- a/declarative/syncprofilewatcher.h
+++ b/declarative/syncprofilewatcher.h
@@ -66,7 +66,7 @@ public:
 
     bool synchronizing() const;
 
-    Q_INVOKABLE void startSync() const;
+    Q_INVOKABLE void startSync();
     Q_INVOKABLE void abortSync() const;
 
 signals:

--- a/declarative/syncprofilewatcher.h
+++ b/declarative/syncprofilewatcher.h
@@ -86,7 +86,7 @@ private:
 
 protected:
     ProfileManager mManager;
-    SyncClientInterface mSyncClient;
+    QSharedPointer<SyncClientInterface> mSyncClient;
     SyncProfile *mSyncProfile;
     QVariantMap mKeys;
     Sync::SyncStatus mSyncStatus;

--- a/declarative/syncresultmodelbase.cpp
+++ b/declarative/syncresultmodelbase.cpp
@@ -29,8 +29,9 @@ using namespace Buteo;
 
 SyncResultModelBase::SyncResultModelBase(QObject *parent)
     : QAbstractListModel(parent)
+    , mSyncClient(SyncClientInterface::sharedInstance())
 {
-    connect(&mSyncClient, &SyncClientInterface::profileChanged,
+    connect(mSyncClient.data(), &SyncClientInterface::profileChanged,
             this, &SyncResultModelBase::onProfileChanged);
 }
 

--- a/declarative/syncresultmodelbase.h
+++ b/declarative/syncresultmodelbase.h
@@ -58,7 +58,7 @@ protected:
     void addProfileResults(QSharedPointer<SyncProfile> &profile);
     virtual void sort();
 
-    SyncClientInterface mSyncClient;
+    QSharedPointer<SyncClientInterface> mSyncClient;
     ProfileManager mManager;
     struct SyncResultEntry {
         QSharedPointer<SyncProfile> profile;

--- a/libbuteosyncfw/clientfw/SyncClientInterface.cpp
+++ b/libbuteosyncfw/clientfw/SyncClientInterface.cpp
@@ -24,6 +24,8 @@
 #include "SyncClientInterface.h"
 #include "SyncClientInterfacePrivate.h"
 
+#include <QDBusPendingCallWatcher>
+
 using namespace Buteo;
 
 QSharedPointer<SyncClientInterface> SyncClientInterface::sharedInstance()
@@ -55,6 +57,11 @@ bool SyncClientInterface::startSync(const QString &aProfileId) const
     return d_ptr->startSync(aProfileId);
 }
 
+QDBusPendingCallWatcher* SyncClientInterface::requestSync(const QString &aProfileId, QObject *aParent) const
+{
+    return d_ptr->requestSync(aProfileId, aParent);
+}
+
 void SyncClientInterface::abortSync(const QString &aProfileId) const
 {
     d_ptr->abortSync(aProfileId);
@@ -63,6 +70,11 @@ void SyncClientInterface::abortSync(const QString &aProfileId) const
 QStringList SyncClientInterface::getRunningSyncList() const
 {
     return d_ptr->getRunningSyncList();
+}
+
+QDBusPendingCallWatcher* SyncClientInterface::requestRunningSyncList(QObject *aParent) const
+{
+    return d_ptr->requestRunningSyncList(aParent);
 }
 
 bool SyncClientInterface::removeProfile(const QString &aProfileId) const
@@ -106,6 +118,11 @@ QList<QString /*profileAsXml*/> SyncClientInterface::allVisibleSyncProfiles()
     return d_ptr->allVisibleSyncProfiles();
 }
 
+QDBusPendingCallWatcher* SyncClientInterface::requestAllVisibleSyncProfiles(QObject *aParent) const
+{
+    return d_ptr->requestAllVisibleSyncProfiles(aParent);
+}
+
 
 QString SyncClientInterface::syncProfile(const QString &aProfileId)
 {
@@ -117,6 +134,11 @@ QStringList SyncClientInterface::syncProfilesByKey(const QString &aKey, const QS
     return d_ptr->syncProfilesByKey(aKey, aValue);
 }
 
+QDBusPendingCallWatcher* SyncClientInterface::requestSyncProfilesByKey(const QString &aKey, const QString &aValue, QObject *aParent) const
+{
+    return d_ptr->requestSyncProfilesByKey(aKey, aValue, aParent);
+}
+
 QStringList SyncClientInterface::syncProfilesByType(const QString &aType)
 {
     return d_ptr->syncProfilesByType(aType);
@@ -125,4 +147,9 @@ QStringList SyncClientInterface::syncProfilesByType(const QString &aType)
 QStringList SyncClientInterface::profilesByType(const QString &aType)
 {
     return d_ptr->profilesByType(aType);
+}
+
+QDBusPendingCallWatcher* SyncClientInterface::requestProfilesByType(const QString &aType, QObject *aParent) const
+{
+    return d_ptr->requestProfilesByType(aType, aParent);
 }

--- a/libbuteosyncfw/clientfw/SyncClientInterface.cpp
+++ b/libbuteosyncfw/clientfw/SyncClientInterface.cpp
@@ -26,6 +26,18 @@
 
 using namespace Buteo;
 
+QSharedPointer<SyncClientInterface> SyncClientInterface::sharedInstance()
+{
+    static QWeakPointer<SyncClientInterface> sharedObj;
+    QSharedPointer<SyncClientInterface> obj = sharedObj.toStrongRef();
+
+    if (!obj) {
+        obj = QSharedPointer<SyncClientInterface>(new SyncClientInterface);
+        sharedObj = obj;
+    }
+    return obj;
+}
+
 SyncClientInterface::SyncClientInterface():
     d_ptr(new SyncClientInterfacePrivate(this))
 {

--- a/libbuteosyncfw/clientfw/SyncClientInterface.cpp
+++ b/libbuteosyncfw/clientfw/SyncClientInterface.cpp
@@ -48,22 +48,22 @@ void SyncClientInterface::abortSync(const QString &aProfileId) const
     d_ptr->abortSync(aProfileId);
 }
 
-QStringList SyncClientInterface::getRunningSyncList()
+QStringList SyncClientInterface::getRunningSyncList() const
 {
     return d_ptr->getRunningSyncList();
 }
 
-bool SyncClientInterface::removeProfile(QString &aProfileId)
+bool SyncClientInterface::removeProfile(const QString &aProfileId) const
 {
     return d_ptr->removeProfile(aProfileId);
 }
 
-bool SyncClientInterface::updateProfile(Buteo::SyncProfile &aProfile)
+bool SyncClientInterface::updateProfile(const Buteo::SyncProfile &aProfile)
 {
     return d_ptr->updateProfile(aProfile);
 }
 
-bool SyncClientInterface::setSyncSchedule(QString &aProfileId, SyncSchedule &aSchedule)
+bool SyncClientInterface::setSyncSchedule(const QString &aProfileId, const SyncSchedule &aSchedule)
 {
     return d_ptr->setSyncSchedule(aProfileId, aSchedule);
 }
@@ -78,7 +78,7 @@ bool SyncClientInterface::getBackUpRestoreState()
     return d_ptr->getBackUpRestoreState();
 }
 
-bool SyncClientInterface::isValid()
+bool SyncClientInterface::isValid() const
 {
     return d_ptr->isValid();
 }

--- a/libbuteosyncfw/clientfw/SyncClientInterface.cpp
+++ b/libbuteosyncfw/clientfw/SyncClientInterface.cpp
@@ -121,3 +121,8 @@ QStringList SyncClientInterface::syncProfilesByType(const QString &aType)
 {
     return d_ptr->syncProfilesByType(aType);
 }
+
+QStringList SyncClientInterface::profilesByType(const QString &aType)
+{
+    return d_ptr->profilesByType(aType);
+}

--- a/libbuteosyncfw/clientfw/SyncClientInterface.h
+++ b/libbuteosyncfw/clientfw/SyncClientInterface.h
@@ -26,6 +26,7 @@
 
 #include <QObject>
 #include <QString>
+#include <QSharedPointer>
 #include <Profile.h>
 #include <SyncProfile.h>
 #include <SyncResults.h>
@@ -188,6 +189,15 @@ public:
      * \return The sync profile ids as string list.
      */
     QStringList syncProfilesByType(const QString &aType);
+    /*!
+     * \brief creates a process singleton
+     *
+     * Use this instance to share a same D-Bus connection to the daemon
+     * between several clients in a process.
+     * \return a singleton instance, don't free it.
+     */
+    static QSharedPointer<SyncClientInterface> sharedInstance();
+
 signals:
 
     /*! \brief Notifies when the synchronisation service is available or not.

--- a/libbuteosyncfw/clientfw/SyncClientInterface.h
+++ b/libbuteosyncfw/clientfw/SyncClientInterface.h
@@ -141,8 +141,8 @@ public:
     bool  getBackUpRestoreState();
 
     /*!
-     * \brief Use this function to understand if the creation of dbus connection to msyncd
-     *        succeeded or not.
+     * \brief Use this function to understand if the dbus connection to msyncd
+     *        is working or not.
      * \return  - status of the dbus object created for msyncd
      */
     bool isValid() const;
@@ -189,6 +189,12 @@ public:
      */
     QStringList syncProfilesByType(const QString &aType);
 signals:
+
+    /*! \brief Notifies when the synchronisation service is available or not.
+     *
+     * This signal is sent when the synchronisation daemon is rnning or not.
+     */
+    void isValidChanged();
 
     /*! \brief Notifies about Backup start.
      *

--- a/libbuteosyncfw/clientfw/SyncClientInterface.h
+++ b/libbuteosyncfw/clientfw/SyncClientInterface.h
@@ -32,6 +32,7 @@
 #include <SyncResults.h>
 #include <SyncSchedule.h>
 
+class QDBusPendingCallWatcher;
 
 namespace Buteo {
 
@@ -78,6 +79,15 @@ public:
     bool startSync(const QString &aProfileId) const;
 
     /*!
+     * \brief asynchronous version of startSync()
+     *
+     * \param aProfileId Id of the profile to use in sync.
+     * \param aParent set the parent of the returned QDBusPendingCallWatcher.
+     * \return a newly created watcher on a QDBusPendingReply<bool>.
+     */
+    QDBusPendingCallWatcher* requestSync(const QString &aProfileId, QObject *aParent = nullptr) const;
+
+    /*!
      * \brief Stops synchronizing the profile with the given Id.
      *
      * If the sync request is still in queue and not yet started, the queue
@@ -93,6 +103,14 @@ public:
      * \return Profile name list.
      */
     QStringList getRunningSyncList() const;
+
+    /*!
+     * \brief asynchronous version of getRunningSyncList()
+     *
+     * \param aParent set the parent of the returned QDBusPendingCallWatcher.
+     * \return a newly created watcher on a QDBusPendingReply<QStringList>.
+     */
+    QDBusPendingCallWatcher* requestRunningSyncList(QObject *aParent = nullptr) const;
 
 
     /*!
@@ -162,6 +180,14 @@ public:
      */
     QList<QString /*profileAsXml*/> allVisibleSyncProfiles();
 
+    /*!
+     * \brief asynchronous version of allVisibleSyncProfiles()
+     *
+     * \param aParent set the parent of the returned QDBusPendingCallWatcher.
+     * \return a newly created watcher on a QDBusPendingReply<QStringList>.
+     */
+    QDBusPendingCallWatcher* requestAllVisibleSyncProfiles(QObject *aParent = nullptr) const;
+
     /*! \brief Gets a sync profile.
      *
      * Loads and merges also all sub-profiles that are referenced from the
@@ -183,12 +209,30 @@ public:
      */
     QStringList syncProfilesByKey(const QString &aKey, const QString &aValue);
 
+    /*! \brief asynchronous version of syncProfilesByKey().
+     *
+     * \param aKey Key to match for profile.
+     * \param aValue Value to match for profile.
+     * \param aParent set the parent of the returned QDBusPendingCallWatcher.
+     * \return a newly created watcher on a QDBusPendingReply<QStringList>.
+     */
+    QDBusPendingCallWatcher* requestSyncProfilesByKey(const QString &aKey, const QString &aValue, QObject *aParent = nullptr) const;
+
     /*! \brief Gets profiles matching the profile type.
      *
      * \param aType Type of the profile service/storage/sync.
      * \return The profiles as Xml string list.
      */
     QStringList profilesByType(const QString &aType);
+
+    /*!
+     * \brief asynchronous version of profilesByType()
+     *
+     * \param aType Type of the profile service/storage/sync.
+     * \param aParent set the parent of the returned QDBusPendingCallWatcher.
+     * \return a newly created watcher on a QDBusPendingReply<QStringList>.
+     */
+    QDBusPendingCallWatcher* requestProfilesByType(const QString &aProfileId, QObject *aParent = nullptr) const;
 
     /*! \brief Gets a profiles  matching the profile type.
      *

--- a/libbuteosyncfw/clientfw/SyncClientInterface.h
+++ b/libbuteosyncfw/clientfw/SyncClientInterface.h
@@ -183,12 +183,20 @@ public:
      */
     QStringList syncProfilesByKey(const QString &aKey, const QString &aValue);
 
+    /*! \brief Gets profiles matching the profile type.
+     *
+     * \param aType Type of the profile service/storage/sync.
+     * \return The profiles as Xml string list.
+     */
+    QStringList profilesByType(const QString &aType);
+
     /*! \brief Gets a profiles  matching the profile type.
      *
      * \param aType Type of the profile service/storage/sync.
      * \return The sync profile ids as string list.
      */
     QStringList syncProfilesByType(const QString &aType);
+
     /*!
      * \brief creates a process singleton
      *

--- a/libbuteosyncfw/clientfw/SyncClientInterface.h
+++ b/libbuteosyncfw/clientfw/SyncClientInterface.h
@@ -91,7 +91,7 @@ public:
      *
      * \return Profile name list.
      */
-    QStringList getRunningSyncList();
+    QStringList getRunningSyncList() const;
 
 
     /*!
@@ -105,7 +105,7 @@ public:
      *
      * \return status of the operation
      */
-    bool setSyncSchedule(QString &aProfileId, SyncSchedule &aSchedule);
+    bool setSyncSchedule(const QString &aProfileId, const SyncSchedule &aSchedule);
 
     /*!
      * \brief Save SyncResults to log.xml file.
@@ -121,7 +121,7 @@ public:
      * \param aProfileId Id of the profile to be deleted.
      * \return status of the remove operation
      */
-    bool removeProfile(QString &aProfileId);
+    bool removeProfile(const QString &aProfileId) const;
 
     /*!
      * \brief This function should be called when sync profile information has
@@ -132,7 +132,7 @@ public:
      * \return status of the update operation
      *
      */
-    bool updateProfile(Buteo::SyncProfile &aSyncProfile);
+    bool updateProfile(const Buteo::SyncProfile &aSyncProfile);
 
     /*!
     * \brief This function returns true if backup/restore in progress else
@@ -145,7 +145,7 @@ public:
      *        succeeded or not.
      * \return  - status of the dbus object created for msyncd
      */
-    bool isValid();
+    bool isValid() const;
 
     /*! \brief To get lastSyncResult.
      *  \param aProfileId

--- a/libbuteosyncfw/clientfw/SyncClientInterfacePrivate.cpp
+++ b/libbuteosyncfw/clientfw/SyncClientInterfacePrivate.cpp
@@ -114,7 +114,7 @@ QStringList SyncClientInterfacePrivate::getRunningSyncList()
     return runningSyncList;
 }
 
-bool SyncClientInterfacePrivate::removeProfile(QString &aProfileId)
+bool SyncClientInterfacePrivate::removeProfile(const QString &aProfileId)
 {
     FUNCTION_CALL_TRACE(lcButeoTrace);
     bool status = false;
@@ -124,7 +124,7 @@ bool SyncClientInterfacePrivate::removeProfile(QString &aProfileId)
     return status;
 }
 
-bool SyncClientInterfacePrivate::updateProfile(Buteo::SyncProfile &aProfile)
+bool SyncClientInterfacePrivate::updateProfile(const Buteo::SyncProfile &aProfile)
 {
     FUNCTION_CALL_TRACE(lcButeoTrace);
     bool status = false;
@@ -155,8 +155,8 @@ void SyncClientInterfacePrivate::resultsAvailable(QString aProfileId,
     }
 }
 
-bool SyncClientInterfacePrivate::setSyncSchedule(QString &aProfileId,
-                                                 SyncSchedule &aSchedule)
+bool SyncClientInterfacePrivate::setSyncSchedule(const QString &aProfileId,
+                                                 const SyncSchedule &aSchedule)
 {
     FUNCTION_CALL_TRACE(lcButeoTrace);
     bool status = false;

--- a/libbuteosyncfw/clientfw/SyncClientInterfacePrivate.cpp
+++ b/libbuteosyncfw/clientfw/SyncClientInterfacePrivate.cpp
@@ -40,6 +40,11 @@ SyncClientInterfacePrivate::SyncClientInterfacePrivate(SyncClientInterface *aPar
     iParent(aParent)
 {
     FUNCTION_CALL_TRACE(lcButeoTrace);
+    iServiceWatcher.addWatchedService(SYNC_DBUS_SERVICE);
+    iServiceWatcher.setConnection(QDBusConnection::sessionBus());
+    connect(&iServiceWatcher, &QDBusServiceWatcher::serviceOwnerChanged,
+            this, &SyncClientInterfacePrivate::onServiceOwnerChanged);
+
     iSyncDaemon = new SyncDaemonProxy(SYNC_DBUS_SERVICE, SYNC_DBUS_OBJECT,
                                       QDBusConnection::sessionBus(), this);
 
@@ -82,6 +87,15 @@ SyncClientInterfacePrivate::~SyncClientInterfacePrivate()
     FUNCTION_CALL_TRACE(lcButeoTrace);
     delete iSyncDaemon;
     iSyncDaemon = nullptr;
+}
+
+void SyncClientInterfacePrivate::onServiceOwnerChanged(const QString &serviceName, const QString &oldOwner, const QString &newOwner)
+{
+    Q_UNUSED(serviceName);
+    Q_UNUSED(oldOwner);
+    Q_UNUSED(newOwner);
+
+    emit iParent->isValidChanged();
 }
 
 bool SyncClientInterfacePrivate::startSync(const QString &aProfileId) const

--- a/libbuteosyncfw/clientfw/SyncClientInterfacePrivate.cpp
+++ b/libbuteosyncfw/clientfw/SyncClientInterfacePrivate.cpp
@@ -285,3 +285,15 @@ QStringList SyncClientInterfacePrivate::syncProfilesByType(const QString &aType)
 
     return profileIds;
 }
+
+QStringList SyncClientInterfacePrivate::profilesByType(const QString &aType)
+{
+    FUNCTION_CALL_TRACE(lcButeoTrace);
+    QStringList profileIds;
+
+    if (iSyncDaemon) {
+        profileIds = iSyncDaemon->profilesByType(aType);
+    }
+
+    return profileIds;
+}

--- a/libbuteosyncfw/clientfw/SyncClientInterfacePrivate.cpp
+++ b/libbuteosyncfw/clientfw/SyncClientInterfacePrivate.cpp
@@ -110,6 +110,13 @@ bool SyncClientInterfacePrivate::startSync(const QString &aProfileId) const
     return syncStatus;
 }
 
+QDBusPendingCallWatcher* SyncClientInterfacePrivate::requestSync(const QString &aProfileId, QObject *aParent)
+{
+    FUNCTION_CALL_TRACE(lcButeoTrace);
+
+    return new QDBusPendingCallWatcher(iSyncDaemon->startSync(aProfileId), aParent ? aParent : this);
+}
+
 void SyncClientInterfacePrivate::abortSync(const QString &aProfileId) const
 {
     FUNCTION_CALL_TRACE(lcButeoTrace);
@@ -126,6 +133,13 @@ QStringList SyncClientInterfacePrivate::getRunningSyncList()
         runningSyncList = iSyncDaemon->runningSyncs();
     }
     return runningSyncList;
+}
+
+QDBusPendingCallWatcher* SyncClientInterfacePrivate::requestRunningSyncList(QObject *aParent)
+{
+    FUNCTION_CALL_TRACE(lcButeoTrace);
+
+    return new QDBusPendingCallWatcher(iSyncDaemon->runningSyncs(), aParent ? aParent : this);
 }
 
 bool SyncClientInterfacePrivate::removeProfile(const QString &aProfileId)
@@ -248,6 +262,12 @@ QList<QString /*profilesAsXml*/> SyncClientInterfacePrivate::allVisibleSyncProfi
     return profilesAsXml;
 }
 
+QDBusPendingCallWatcher* SyncClientInterfacePrivate::requestAllVisibleSyncProfiles(QObject *aParent)
+{
+    FUNCTION_CALL_TRACE(lcButeoTrace);
+
+    return new QDBusPendingCallWatcher(iSyncDaemon->allVisibleSyncProfiles(), aParent ? aParent : this);
+}
 
 QString SyncClientInterfacePrivate::syncProfile(const QString &aProfileId)
 {
@@ -274,6 +294,13 @@ QStringList SyncClientInterfacePrivate::syncProfilesByKey(const QString &aKey, c
     return profileAsXml;
 }
 
+QDBusPendingCallWatcher* SyncClientInterfacePrivate::requestSyncProfilesByKey(const QString &aKey, const QString &aValue, QObject *aParent)
+{
+    FUNCTION_CALL_TRACE(lcButeoTrace);
+
+    return new QDBusPendingCallWatcher(iSyncDaemon->syncProfilesByKey(aKey, aValue), aParent ? aParent : this);
+}
+
 QStringList SyncClientInterfacePrivate::syncProfilesByType(const QString &aType)
 {
     FUNCTION_CALL_TRACE(lcButeoTrace);
@@ -296,4 +323,11 @@ QStringList SyncClientInterfacePrivate::profilesByType(const QString &aType)
     }
 
     return profileIds;
+}
+
+QDBusPendingCallWatcher* SyncClientInterfacePrivate::requestProfilesByType(const QString &aType, QObject *aParent)
+{
+    FUNCTION_CALL_TRACE(lcButeoTrace);
+
+    return new QDBusPendingCallWatcher(iSyncDaemon->profilesByType(aType), aParent ? aParent : this);
 }

--- a/libbuteosyncfw/clientfw/SyncClientInterfacePrivate.h
+++ b/libbuteosyncfw/clientfw/SyncClientInterfacePrivate.h
@@ -25,6 +25,7 @@
 #define SYNCCLIENTINTERFACEPRIVATE_H
 
 #include <QObject>
+#include <QDBusPendingCallWatcher>
 #include <QDBusServiceWatcher>
 #include "SyncDaemonProxy.h"
 #include <SyncProfile.h>
@@ -56,6 +57,7 @@ public:
      * @param aProfileId - id of the profile to start the sync
      */
     bool startSync(const QString &aProfileId) const;
+    QDBusPendingCallWatcher* requestSync(const QString &aProfileId, QObject *aParent);
 
     /*! \brief function to abort the sync
      *
@@ -68,6 +70,7 @@ public:
      * @return  - list of running sync profile ids
      */
     QStringList getRunningSyncList();
+    QDBusPendingCallWatcher* requestRunningSyncList(QObject *aParent);
 
     /*! \brief function to remove a profile
      *
@@ -127,6 +130,7 @@ public:
      * \return The list of sync profiles.
      */
     QList<QString /*profileAsXml*/> allVisibleSyncProfiles();
+    QDBusPendingCallWatcher* requestAllVisibleSyncProfiles(QObject *aParent);
 
     /*! \brief Gets a sync profile.
      *
@@ -148,6 +152,7 @@ public:
      * \return The sync profiles as Xml string list.
      */
     QStringList syncProfilesByKey(const QString &aKey, const QString &aValue);
+    QDBusPendingCallWatcher* requestSyncProfilesByKey(const QString &aKey, const QString &aValue, QObject *aParent);
 
     /*! \brief Gets profiles matching the profile type.
      *
@@ -155,6 +160,7 @@ public:
      * \return The profiles as Xml string list.
      */
     QStringList profilesByType(const QString &aType);
+    QDBusPendingCallWatcher* requestProfilesByType(const QString &aType, QObject *aParent);
 
     /*! \brief Gets a profiles  matching the profile type.
      *

--- a/libbuteosyncfw/clientfw/SyncClientInterfacePrivate.h
+++ b/libbuteosyncfw/clientfw/SyncClientInterfacePrivate.h
@@ -25,6 +25,7 @@
 #define SYNCCLIENTINTERFACEPRIVATE_H
 
 #include <QObject>
+#include <QDBusServiceWatcher>
 #include "SyncDaemonProxy.h"
 #include <SyncProfile.h>
 
@@ -215,8 +216,10 @@ signals:
     void resultsAvailable(QString aProfileId, Buteo::SyncResults aLastResults);
 
 private:
+    void onServiceOwnerChanged(const QString &serviceName, const QString &oldOwner, const QString &newOwner);
 
     SyncDaemonProxy *iSyncDaemon;
+    QDBusServiceWatcher iServiceWatcher;
 
     Buteo::SyncClientInterface *iParent;
 

--- a/libbuteosyncfw/clientfw/SyncClientInterfacePrivate.h
+++ b/libbuteosyncfw/clientfw/SyncClientInterfacePrivate.h
@@ -149,6 +149,13 @@ public:
      */
     QStringList syncProfilesByKey(const QString &aKey, const QString &aValue);
 
+    /*! \brief Gets profiles matching the profile type.
+     *
+     * \param aType Type of the profile service/storage/sync.
+     * \return The profiles as Xml string list.
+     */
+    QStringList profilesByType(const QString &aType);
+
     /*! \brief Gets a profiles  matching the profile type.
      *
      * \param aType Type of the profile service/storage/sync.

--- a/libbuteosyncfw/clientfw/SyncClientInterfacePrivate.h
+++ b/libbuteosyncfw/clientfw/SyncClientInterfacePrivate.h
@@ -72,13 +72,13 @@ public:
      *
      * @param aProfileId id of the profule to remove to add
      */
-    bool removeProfile(QString &aProfileId);
+    bool removeProfile(const QString &aProfileId);
 
     /*! \brief function to update an existing profile
      *
      * @param aProfile profile object to add
      */
-    bool updateProfile(Buteo::SyncProfile &aProfile);
+    bool updateProfile(const Buteo::SyncProfile &aProfile);
 
     /*! \brief function to add a profile
      *
@@ -103,7 +103,7 @@ public:
      * @param aProfileId - profile id
      * @param aSchedule - schedule object
      */
-    bool setSyncSchedule(QString &aProfileId, SyncSchedule &aSchedule);
+    bool setSyncSchedule(const QString &aProfileId, const SyncSchedule &aSchedule);
 
     /*! \brief this function converts the save the syncResults into
      * log.xml file corresponding to profileName.

--- a/libbuteosyncfw/clientfw/SyncDaemonProxy.h
+++ b/libbuteosyncfw/clientfw/SyncDaemonProxy.h
@@ -212,6 +212,14 @@ public Q_SLOTS: // METHODS
         return asyncCallWithArgumentList(QLatin1String("syncProfilesByType"), argumentList);
     }
 
+    //! \see SyncDBusInterface::profilesByType
+    inline QDBusPendingReply<QStringList> profilesByType(const QString &aType)
+    {
+        QList<QVariant> argumentList;
+        argumentList << qVariantFromValue(aType);
+        return asyncCallWithArgumentList(QLatin1String("profilesByType"), argumentList);
+    }
+
     //! \see SyncDBusInterface::updateProfile()
     inline QDBusPendingReply<bool> updateProfile(const QString &aProfileAsXml)
     {

--- a/libbuteosyncfw/libbuteosyncfw.pro
+++ b/libbuteosyncfw/libbuteosyncfw.pro
@@ -26,7 +26,6 @@ PUBLIC_HEADERS += \
            common/TransportTracker.h \
            common/NetworkManager.h \
            clientfw/SyncClientInterface.h \
-           clientfw/SyncDaemonProxy.h \
            pluginmgr/ClientPlugin.h \
            pluginmgr/DeletedItemsIdStorage.h \
            pluginmgr/PluginCbInterface.h \
@@ -57,6 +56,7 @@ PUBLIC_HEADERS += \
 
 HEADERS += $$PUBLIC_HEADERS \
            clientfw/SyncClientInterfacePrivate.h \
+           clientfw/SyncDaemonProxy.h \
            profile/Profile_p.h \
            profile/SyncSchedule_p.h \
 

--- a/libbuteosyncfw/profile/ProfileManager.h
+++ b/libbuteosyncfw/profile/ProfileManager.h
@@ -234,16 +234,6 @@ public:
      */
     Profile *profile(const QString &aName, const QString &aType);
 
-    /*! \brief Gets a profile object from an xml document.
-     *
-     * \param aProfileAsXml Name of the profile to get.
-     * \return Pointer to the profile. If the xml is not valid, NULL is
-     *  returned. Caller is responsible for deleting the returned object.
-     *  Changes made to the profile are not saved to profile storage, unless
-     *  updateProfile function of this class is called
-     */
-    Profile *profileFromXml(const QString &aProfileAsXml);
-
     /*! \brief Gets a temporary profile (saved if sync is sucessfull).
      *
      * \param btAddress  Address of the remote device bt address/usb .
@@ -346,6 +336,16 @@ public:
     // configPath is the root of primary profile directory, used for writing changes
     // systemConfigPath is for read-only system profiles
     void setPaths(const QString &configPath, const QString &systemConfigPath);
+
+    /*! \brief Gets a profile object from an xml document.
+     *
+     * \param aProfileAsXml Name of the profile to get.
+     * \return Pointer to the profile. If the xml is not valid, NULL is
+     *  returned. Caller is responsible for deleting the returned object.
+     *  Changes made to the profile are not saved to profile storage, unless
+     *  updateProfile function of this class is called
+     */
+    static Profile *profileFromXml(const QString &aProfileAsXml);
 
 signals:
     /*! \brief Notifies about a change in profile.

--- a/msyncd/SyncDBusAdaptor.cpp
+++ b/msyncd/SyncDBusAdaptor.cpp
@@ -187,6 +187,14 @@ QStringList SyncDBusAdaptor::syncProfilesByType(const QString &aType)
     return out0;
 }
 
+QStringList SyncDBusAdaptor::profilesByType(const QString &aType)
+{
+    // handle method call com.meego.msyncd.profilesByType
+    QStringList out0;
+    QMetaObject::invokeMethod(parent(), "profilesByType", Q_RETURN_ARG(QStringList, out0), Q_ARG(QString, aType));
+    return out0;
+}
+
 QList<uint> SyncDBusAdaptor::syncingAccounts()
 {
     // handle method call com.meego.msyncd.syncingAccounts

--- a/msyncd/SyncDBusAdaptor.h
+++ b/msyncd/SyncDBusAdaptor.h
@@ -145,6 +145,10 @@ class SyncDBusAdaptor: public QDBusAbstractAdaptor
                 "      <arg direction=\"out\" type=\"as\"/>\n"
                 "      <arg direction=\"in\" type=\"s\" name=\"aType\"/>\n"
                 "    </method>\n"
+                "    <method name=\"profilesByType\">\n"
+                "      <arg direction=\"out\" type=\"as\"/>\n"
+                "      <arg direction=\"in\" type=\"s\" name=\"aType\"/>\n"
+                "    </method>\n"
                 "    <method name=\"start\">\n"
                 "      <arg direction=\"in\" type=\"u\" name=\"aAccountId\"/>\n"
                 "      <annotation value=\"true\" name=\"org.freedesktop.DBus.Method.NoReply\"/>\n"
@@ -199,6 +203,7 @@ public Q_SLOTS: // METHODS
     QString syncProfile(const QString &aProfileId);
     QStringList syncProfilesByKey(const QString &aKey, const QString &aValue);
     QStringList syncProfilesByType(const QString &aType);
+    QStringList profilesByType(const QString &aType);
     QList<uint> syncingAccounts();
     bool updateProfile(const QString &aProfileAsXml);
     Q_NOREPLY void isSyncedExternally(uint aAccountId, const QString aClientProfileName);

--- a/msyncd/SyncDBusInterface.h
+++ b/msyncd/SyncDBusInterface.h
@@ -325,6 +325,13 @@ public slots:
      */
     virtual QStringList syncProfilesByKey(const QString &aKey, const QString &aValue) = 0;
 
+    /*! \brief Gets all profiles matching the profile type.
+     *
+     * \param aType Type of the profile service/storage/sync.
+     * \return The sync profiles as Xml string list.
+     */
+    virtual QStringList profilesByType(const QString &aType) = 0;
+
     /*! \brief Gets a profiles  matching the profile type.
      *
      * \param aType Type of the profile service/storage/sync.

--- a/msyncd/synchronizer.cpp
+++ b/msyncd/synchronizer.cpp
@@ -1818,6 +1818,23 @@ QStringList Synchronizer::syncProfilesByType(const QString &aType)
     return iProfileManager.profileNames(aType);
 }
 
+QStringList Synchronizer::profilesByType(const QString &aType)
+{
+    FUNCTION_CALL_TRACE(lcButeoTrace);
+    QStringList profilesAsXml;
+
+    qCDebug(lcButeoMsyncd) << "Profile Type : " << aType;
+    for (const QString &profileId : iProfileManager.profileNames(aType)) {
+        SyncProfile *profile = iProfileManager.syncProfile(profileId);
+        if (profile) {
+            profilesAsXml.append(profile->toString());
+        }
+        delete profile;
+    }
+    qCDebug(lcButeoMsyncd) << "profilesByType profilesAsXml" << profilesAsXml;
+    return profilesAsXml;
+}
+
 void Synchronizer::onNetworkStateChanged(bool aState, Sync::InternetConnectionType type)
 {
     FUNCTION_CALL_TRACE(lcButeoTrace);

--- a/msyncd/synchronizer.h
+++ b/msyncd/synchronizer.h
@@ -170,6 +170,7 @@ public slots:
     virtual QString syncProfile(const QString &aProfileId);
     virtual QStringList syncProfilesByKey(const QString &aKey, const QString &aValue);
     virtual QStringList syncProfilesByType(const QString &aType);
+    virtual QStringList profilesByType(const QString &aType) override;
 // --------------------------------------------------------------------------
 
     //! Called  starts a schedule sync.

--- a/rpm/buteo-syncfw-qt5.spec
+++ b/rpm/buteo-syncfw-qt5.spec
@@ -24,9 +24,6 @@ BuildRequires: pkgconfig(gio-2.0)
 BuildRequires: pkgconfig(mce-qt5) >= 1.1.0
 BuildRequires: pkgconfig(systemd)
 BuildRequires: oneshot
-Requires: mapplauncherd-qt5
-Requires: glib2
-Requires: libmce-qt5 >= 1.1.0
 Requires: oneshot
 %{_oneshot_requires_post}
 
@@ -45,6 +42,7 @@ Summary: Buteo sync daemon
 Requires: %{name} = %{version}-%{release}
 Requires: systemd
 Requires: systemd-user-session-targets
+Requires: mapplauncherd-qt5
 Provides: buteo-syncfw-msyncd = %{version}
 Obsoletes: buteo-syncfw-msyncd < %{version}
 


### PR DESCRIPTION
These are various commits, fixing some minor glitches, but overall driven by this downstream QML plugin from UBport : https://gitlab.com/ubports/development/core/buteo-syncfw-qml/-/blob/main/Buteo/buteo-sync-qml.h?ref_type=heads

In a medium term, the idea is to provide them QML bindings inside Buteo itself to replace their implementation. This is also usefull for my QML project of log viewing.

In a short term, this PR tries to correct some of the deficiencies of the SyncClientInterface API. This API is used to interface with the `msyncd` daemon internally via its D-Bus API without actually having to handle D-Bus interface in the client code… But the biggest issue is the fact that the API is synchronous, which makes its usage inside a QML plugin quite a pain since most of the methods are returning arguments (like listing running sync profiles…). I'm proposing to add asynchronous versions of the API in SyncClientInterface. This API is returning a pointer over a QtDBus object, so there is no any D-Bus include in the public headers. If one is not using the asynchronous API, there is no need to declare QT += dbus.

Then, the last commit is adding a new QML object that can be used in the medium term to replace the one created by UBport.