### PR TITLE
[msyncd] Add method to enable/disable sync profiles for a specific service

### DIFF
--- a/msyncd/AccountsHelper.h
+++ b/msyncd/AccountsHelper.h
@@ -92,6 +92,7 @@ private Q_SLOTS:
 
 private:
     void syncEnableWithAccount(Accounts::Account *account);
+    void syncEnableWithService(Accounts::Account *account, const QString &serviceName, bool enabled);
     bool addProfileForAccount(Accounts::Account *account,
                               const QString &serviceName,
                               bool serviceEnabled,


### PR DESCRIPTION
Add method to enable/disable sync profiles for a specific service
Ensure the profile is created if it does not already exist.

Fixes the issue where a service can be added later. Also ensures that only sync profiles for the specified service are affected when enabling or disabling it.