### PR TITLE
Rename method, whitespace type of cleanups

### DIFF
--- a/libbuteosyncfw/clientfw/SyncClientInterface.h
+++ b/libbuteosyncfw/clientfw/SyncClientInterface.h
@@ -112,7 +112,6 @@ public:
      */
     QDBusPendingCallWatcher* requestRunningSyncList(QObject *aParent = nullptr) const;
 
-
     /*!
      * \brief Sets Sync Schedule to the profile
      *
@@ -251,7 +250,6 @@ public:
     static QSharedPointer<SyncClientInterface> sharedInstance();
 
 signals:
-
     /*! \brief Notifies when the synchronisation service is available or not.
      *
      * This signal is sent when the synchronisation daemon is rnning or not.
@@ -353,12 +351,9 @@ signals:
                           int aTransferType, QString aMimeType, int aCommittedItems);
 
 private:
-
     SyncClientInterfacePrivate *d_ptr;
 };
 
-
 };
-
 
 #endif

--- a/libbuteosyncfw/clientfw/SyncClientInterfacePrivate.h
+++ b/libbuteosyncfw/clientfw/SyncClientInterfacePrivate.h
@@ -41,6 +41,7 @@ class SyncClientInterface;
 class SyncClientInterfacePrivate: public QObject
 {
     Q_OBJECT
+
 public:
     /*!\brief Constructor
      *
@@ -170,7 +171,6 @@ public:
     QStringList syncProfilesByType(const QString &aType);
 
 public slots:
-
     /*! \brief this is the slot where we will receive the xml data for profile from msyncd.
      * The XML Data received will be of the following format
      * \code <?xml version="1.0" encoding="UTF-8"?>
@@ -212,7 +212,6 @@ public slots:
     void resultsAvailable(QString aProfileId, QString aLastSyncResultAsXml);
 
 signals:
-
     /*! \brief Signal that gets emitted on receiving profileChanged from msyncd
      *
      * @param   aProfileId - id of the profile

--- a/libbuteosyncfw/pluginmgr/ClientPlugin.cpp
+++ b/libbuteosyncfw/pluginmgr/ClientPlugin.cpp
@@ -34,5 +34,4 @@ ClientPlugin::ClientPlugin(const QString &aPluginName,
 
 ClientPlugin::~ClientPlugin()
 {
-
 }

--- a/libbuteosyncfw/profile/Profile.cpp
+++ b/libbuteosyncfw/profile/Profile.cpp
@@ -45,17 +45,17 @@ const QString Profile::TYPE_SYNC("sync");
 Profile::Profile()
     : d_ptr(new ProfilePrivate())
 {
-
 }
+
 Profile::Profile(const QString &aName, const QString &aType)
-    :   d_ptr(new ProfilePrivate())
+    : d_ptr(new ProfilePrivate())
 {
     d_ptr->iName = aName;
     d_ptr->iType = aType;
 }
 
 Profile::Profile(const QDomElement &aRoot)
-    :   d_ptr(new ProfilePrivate())
+    : d_ptr(new ProfilePrivate())
 {
     d_ptr->iName = aRoot.attribute(ATTR_NAME);
     d_ptr->iType = aRoot.attribute(ATTR_TYPE);
@@ -90,7 +90,7 @@ Profile::Profile(const QDomElement &aRoot)
 }
 
 Profile::Profile(const Profile &aSource)
-    :   d_ptr(new ProfilePrivate(*aSource.d_ptr))
+    : d_ptr(new ProfilePrivate(*aSource.d_ptr))
 {
 }
 

--- a/libbuteosyncfw/profile/SyncProfile.cpp
+++ b/libbuteosyncfw/profile/SyncProfile.cpp
@@ -35,9 +35,7 @@ class SyncProfilePrivate
 {
 public:
     SyncProfilePrivate();
-
     SyncProfilePrivate(const SyncProfilePrivate &aSource);
-
     ~SyncProfilePrivate();
 
     SyncLog *iLog;

--- a/libbuteosyncfw/profile/SyncSchedule.cpp
+++ b/libbuteosyncfw/profile/SyncSchedule.cpp
@@ -36,37 +36,43 @@ using namespace Buteo;
 static const QString DAY_SEPARATOR = ",";
 
 SyncSchedulePrivate::SyncSchedulePrivate()
-    :   iDays(SyncSchedule::NoDays), iInterval(0), iEnabled(false), iRushDays(SyncSchedule::NoDays), iRushInterval(0), iRushEnabled(false), iExternalRushEnabled(false)
+    : iDays(SyncSchedule::NoDays)
+    , iInterval(0)
+    , iEnabled(false)
+    , iRushDays(SyncSchedule::NoDays)
+    , iRushInterval(0)
+    , iRushEnabled(false)
+    , iExternalRushEnabled(false)
 {
 }
 
 SyncSchedulePrivate::SyncSchedulePrivate(const SyncSchedulePrivate &aSource)
-    :   iDays(aSource.iDays),
-        iTime(aSource.iTime),
-        iScheduleConfiguredTime(aSource.iScheduleConfiguredTime),
-        iInterval(aSource.iInterval),
-        iEnabled(aSource.iEnabled),
-        iRushDays(aSource.iRushDays),
-        iRushBegin(aSource.iRushBegin),
-        iRushEnd(aSource.iRushEnd),
-        iRushInterval(aSource.iRushInterval),
-        iRushEnabled(aSource.iRushEnabled),
-        iExternalRushEnabled(aSource.iExternalRushEnabled)
+    : iDays(aSource.iDays)
+    , iTime(aSource.iTime)
+    , iScheduleConfiguredTime(aSource.iScheduleConfiguredTime)
+    , iInterval(aSource.iInterval)
+    , iEnabled(aSource.iEnabled)
+    , iRushDays(aSource.iRushDays)
+    , iRushBegin(aSource.iRushBegin)
+    , iRushEnd(aSource.iRushEnd)
+    , iRushInterval(aSource.iRushInterval)
+    , iRushEnabled(aSource.iRushEnabled)
+    , iExternalRushEnabled(aSource.iExternalRushEnabled)
 {
 }
 
 SyncSchedule::SyncSchedule()
-    :   d_ptr(new SyncSchedulePrivate())
+    : d_ptr(new SyncSchedulePrivate())
 {
 }
 
 SyncSchedule::SyncSchedule(const SyncSchedule &aSource)
-    :   d_ptr(new SyncSchedulePrivate(*aSource.d_ptr))
+    : d_ptr(new SyncSchedulePrivate(*aSource.d_ptr))
 {
 }
 
 SyncSchedule::SyncSchedule(const QDomElement &aRoot)
-    :   d_ptr(new SyncSchedulePrivate())
+    : d_ptr(new SyncSchedulePrivate())
 {
     d_ptr->iTime = QTime::fromString(aRoot.attribute(ATTR_TIME), Qt::ISODate);
     d_ptr->iInterval = aRoot.attribute(ATTR_INTERVAL).toUInt();
@@ -652,5 +658,3 @@ bool SyncSchedulePrivate::isRush(const QDateTime &aTime) const
     return (daysMatch(iRushDays, aTime.date().dayOfWeek()) &&
             aTime.time() >= iRushBegin && aTime.time() < iRushEnd);
 }
-
-

--- a/libbuteosyncfw/profile/TargetResults.cpp
+++ b/libbuteosyncfw/profile/TargetResults.cpp
@@ -32,18 +32,19 @@ struct ItemDetails {
     TargetResults::ItemOperationStatus status;
     QString message;
 
-    ItemDetails(): status(TargetResults::ITEM_OPERATION_SUCCEEDED) {};
+    ItemDetails(): status(TargetResults::ITEM_OPERATION_SUCCEEDED) {}
     ItemDetails(const QString &aUid,
                 TargetResults::ItemOperationStatus aStatus,
                 const QString &aMessage)
-        : uid(aUid), status(aStatus), message(aMessage) {};
+        : uid(aUid), status(aStatus), message(aMessage) {}
     ItemDetails(const QDomElement &aRoot)
         : uid(aRoot.attribute(ATTR_UID))
         , status(aRoot.attribute(ATTR_STATUS).compare(QLatin1String("failed"),
-                                                      Qt::CaseInsensitive) ? TargetResults::ITEM_OPERATION_SUCCEEDED : TargetResults::ITEM_OPERATION_FAILED)
+                                                      Qt::CaseInsensitive) ? TargetResults::ITEM_OPERATION_SUCCEEDED
+                                                                           : TargetResults::ITEM_OPERATION_FAILED)
         , message(aRoot.text())
     {
-    };
+    }
 
     QDomElement toXml(QDomDocument &aDoc, const QString &aTag) const
     {

--- a/msyncd/AccountsHelper.cpp
+++ b/msyncd/AccountsHelper.cpp
@@ -34,7 +34,8 @@ static const QString REMOTE_SERVICE_NAME("remote_service_name");
 using namespace Buteo;
 
 AccountsHelper::AccountsHelper(ProfileManager &aProfileManager, QObject *aParent)
-    :   QObject(aParent), iProfileManager(aProfileManager)
+    : QObject(aParent)
+    , iProfileManager(aProfileManager)
 {
     iAccountManager = new Accounts::Manager(this);
     // Connect to signal for account creation and deletion.

--- a/msyncd/AccountsHelper.h
+++ b/msyncd/AccountsHelper.h
@@ -43,7 +43,6 @@ class AccountsHelper : public QObject
     Q_OBJECT
 
 public:
-
     /*! \brief Constructor
      *
      * \param aProfileManager - reference to Profile Manager Object
@@ -65,7 +64,6 @@ public:
     QList<SyncProfile *> getProfilesByAccountId(Accounts::AccountId id);
 
 public Q_SLOTS:
-
     /*! \brief This method is used to create profiles for a specified
      * account
      * \param id Accounts Id
@@ -79,15 +77,14 @@ public Q_SLOTS:
     void slotAccountRemoved(Accounts::AccountId id);
 
     void slotSchedulerSettingsChanged(const char *aKey);
-Q_SIGNALS:
 
+Q_SIGNALS:
     void enableSOC(const QString &aProfileName);
     void scheduleUpdated(const QString &aProfileName);
     void removeProfile(QString profileId);
     void removeScheduledSync(const QString &profileId);
 
 private Q_SLOTS:
-
     void registerAccountListeners();
 
 private:

--- a/msyncd/BackgroundSync.h
+++ b/msyncd/BackgroundSync.h
@@ -122,7 +122,6 @@ public slots:
     void onBackgroundSyncCompleted(QString aProfName);
 
 private slots:
-
     /*! \brief Called when background sync timer starts running
      */
     void onBackgroundSyncStarted();
@@ -132,7 +131,6 @@ private slots:
     void onBackgroundSwitchStarted();
 
 private:
-
     /*! \brief Finds the name of the profile which uses particular background activity
      *
      * \param activityId Id of the background activity
@@ -162,7 +160,6 @@ private:
     QString getProfNameFromSwitchId(const QString activityId) const;
 
 private:
-
     ///Map of structures waiting for background sync
     QMap<QString, BActivityStruct> iScheduledSyncs;
 

--- a/msyncd/ClientPluginRunner.h
+++ b/msyncd/ClientPluginRunner.h
@@ -40,7 +40,6 @@ class ClientPluginRunner : public PluginRunner
     Q_OBJECT
 
 public:
-
     /*! \brief Constructor
      *
      * @param aPluginName Name of the plug-in to run
@@ -80,7 +79,6 @@ public:
     virtual bool cleanUp();
 
 private slots:
-
     // Slots for catching plug-in signals.
 
     void onTransferProgress(const QString &aProfileName,

--- a/msyncd/ClientThread.h
+++ b/msyncd/ClientThread.h
@@ -83,7 +83,6 @@ public:
     SyncResults getSyncResults();
 
 signals:
-
     /*! \brief Emitted when synchronization cannot be started due to an
      *         error in plugin initialization
      *

--- a/msyncd/IPHeartBeat.h
+++ b/msyncd/IPHeartBeat.h
@@ -85,7 +85,6 @@ signals:
     void onHeartBeat(QString aProfName);
 
 private slots:
-
     /*! \brief This signal will be emitted when a socket descriptor gets an event notification.
      *
      * \param aSockFd Socket descriptor who got the event.
@@ -93,7 +92,6 @@ private slots:
     void internalBeatTriggered(int aSockFd);
 
 private:
-
     /*! \brief Finds the name of the profile which uses particular file descriptor
      *
      * \param aSockFd Socket descriptor.

--- a/msyncd/PluginRunner.h
+++ b/msyncd/PluginRunner.h
@@ -46,7 +46,6 @@ class PluginRunner : public QObject
     Q_OBJECT
 
 public:
-
     //! Plug-in type: client or server
     enum PluginType {
         PLUGIN_CLIENT,
@@ -101,7 +100,6 @@ public:
      * @return Sync results
      */
     virtual SyncResults syncResults() = 0;
-
 
     /*! \brief Calls the cleanup for the plugin
      *

--- a/msyncd/ServerThread.h
+++ b/msyncd/ServerThread.h
@@ -37,8 +37,8 @@ class ServerPlugin;
 class ServerThread : public QThread
 {
     Q_OBJECT
-public:
 
+public:
     /*! \brief Constructor
      *
      */

--- a/msyncd/SyncBackupProxy.h
+++ b/msyncd/SyncBackupProxy.h
@@ -45,8 +45,6 @@ class SyncBackupProxy : public QObject
 public:
 
 signals:
-
-
     /*! \brief Notifies about completion of backup.
      *
      * This signal is sent when the backup is completed
@@ -72,7 +70,6 @@ signals:
     void startRestore();
 
 public slots:
-
     /*!
      * \brief Sets the required params and stops the servers and any running sync
      * sessions.

--- a/msyncd/SyncDBusInterface.h
+++ b/msyncd/SyncDBusInterface.h
@@ -46,7 +46,6 @@ class SyncDBusInterface : public QObject
 public:
 
 signals:
-
     /*!
      * \brief Notifies about a change in synchronization status.
      *
@@ -180,7 +179,6 @@ signals:
     void syncedExternallyStatus(uint aAccountId, const QString &aClientProfileName, bool aState);
 
 public slots:
-
     /*!
      * \brief Requests to starts synchronizing using a profile with the given
      *        name.
@@ -259,13 +257,11 @@ public slots:
      */
     virtual QStringList runningSyncs() = 0;
 
-
     /*!
      * \brief This function returns true if backup/restore in progress else
      * false.
      */
     virtual bool  getBackUpRestoreState() = 0;
-
 
     /*!
      * \brief sets the schedule for a profile

--- a/msyncd/SyncScheduler.h
+++ b/msyncd/SyncScheduler.h
@@ -56,7 +56,6 @@ class SyncScheduler : public QObject
     Q_OBJECT
 
 public:
-
     //! \brief Constructor.
     SyncScheduler(QObject *aParent = 0);
 
@@ -110,7 +109,6 @@ public slots:
                            const QString &aMessage, int aMoreDetails);
 
 private slots:
-
 #if defined(USE_IPHB)
     /**
      * \brief Performs needed actions when scheduled alarm is triggered
@@ -153,7 +151,6 @@ signals:
     void externalSyncChanged(QString aProfileName, bool aQuery = false);
 
 private: // functions
-
     /**
      * \brief Programs next alarm event to alarmd.
      *
@@ -182,7 +179,6 @@ private: // functions
 #endif
 
 private: // data
-
     QSet<QString> iActiveBackgroundSyncProfiles;
 #if defined(USE_KEEPALIVE)
     /// BackgroundSync management object

--- a/msyncd/SyncSession.h
+++ b/msyncd/SyncSession.h
@@ -45,7 +45,6 @@ class SyncSession : public QObject
     Q_OBJECT
 
 public:
-
     /*! \brief Constructor
      *
      * @param aProfile SyncProfile associated with the session. With server
@@ -185,7 +184,6 @@ public:
     Sync::SyncStatus mapToSyncStatusError(int aErrorCode);
 
 signals:
-
     //! @see SyncPluginBase::transferProgress
     void transferProgress(const QString &aProfileName,
                           Sync::TransferDatabase aDatabase, Sync::TransferType aType,
@@ -214,32 +212,22 @@ signals:
      * @param aProgressDetail Detail of the progress.
      */
     void syncProgressDetail(const QString &aProfileName, int aProgressDetail);
-private:
 
+private:
     bool tryStart();
 
 private slots:
-
     // Slots for catching plug-in runner signals.
-
     void onSuccess(const QString &aProfileName, const QString &aMessage);
-
     void onError(const QString &aProfileName, const QString &aMessage, SyncResults::MinorCode aErrorCode);
-
     void onTransferProgress(const QString &aProfileName,
                             Sync::TransferDatabase aDatabase, Sync::TransferType aType,
                             const QString &aMimeType, int aCommittedItems);
-
     void onStorageAccquired (const QString &aMimeType);
-
     void onSyncProgressDetail(const QString &aProfileName, int aProgressDetail);
-
     void onDone();
-
     void onDestroyed(QObject *aPluginRunner);
-
     void onNetworkSessionOpened();
-
     void onNetworkSessionError();
 
 private:

--- a/msyncd/synchronizer.cpp
+++ b/msyncd/synchronizer.cpp
@@ -88,16 +88,16 @@ public:
 };
 
 Synchronizer::Synchronizer(QCoreApplication *aApplication)
-    :   iNetworkManager(0),
-        iSyncScheduler(0),
-        iSyncBackup(0),
-        iTransportTracker(0),
-        iServerActivator(0),
-        iAccounts(0),
-        iClosing(false),
-        iSOCEnabled(false),
-        iSyncUIInterface(nullptr),
-        iBatteryInfo(new BatteryInfo)
+    : iNetworkManager(0)
+    , iSyncScheduler(0)
+    , iSyncBackup(0)
+    , iTransportTracker(0)
+    , iServerActivator(0)
+    , iAccounts(0)
+    , iClosing(false)
+    , iSOCEnabled(false)
+    , iSyncUIInterface(nullptr)
+    , iBatteryInfo(new BatteryInfo)
 {
     iSettings = g_settings_new_with_path("com.meego.msyncd", "/com/meego/msyncd/");
     FUNCTION_CALL_TRACE(lcButeoTrace);
@@ -175,7 +175,7 @@ bool Synchronizer::initialize()
     startServers();
 
     // For Backup/restore handling
-    iSyncBackup =  new SyncBackup();
+    iSyncBackup = new SyncBackup();
 
     // Initialize scheduler
     initializeScheduler();
@@ -273,7 +273,6 @@ void Synchronizer::close()
     delete iSyncBackup;
     iSyncBackup = 0;
 
-
     // Unregister from D-Bus.
     QDBusConnection dbus = QDBusConnection::sessionBus();
     dbus.unregisterObject(SYNC_DBUS_OBJECT);
@@ -282,7 +281,6 @@ void Synchronizer::close()
     } else {
         qCDebug(lcButeoMsyncd) << "Unregistered from D-Bus";
     }
-
 }
 
 bool Synchronizer::startSync(QString aProfileName)
@@ -1544,7 +1542,7 @@ void Synchronizer::backupRestoreStarts()
 {
     qCDebug(lcButeoMsyncd) << "Synchronizer:backupRestoreStarts:";
 
-    iClosing =  true;
+    iClosing = true;
     // No active sessions currently !!
     if (iActiveSessions.size() == 0) {
         qCDebug(lcButeoMsyncd) << "No active sync sessions ";
@@ -1554,7 +1552,7 @@ void Synchronizer::backupRestoreStarts()
         // Stop running sessions
         QList<SyncSession *> sessions = iActiveSessions.values();
         foreach (SyncSession *session, sessions) {
-            if (session != 0) {
+            if (session) {
                 session->abort();
             }
         }
@@ -1760,7 +1758,6 @@ QStringList Synchronizer::allVisibleSyncProfiles()
     qCDebug(lcButeoMsyncd) << "allVisibleSyncProfiles profilesAsXml" << profilesAsXml;
     return profilesAsXml;
 }
-
 
 QString Synchronizer::syncProfile(const QString &aProfileId)
 {
@@ -2051,4 +2048,3 @@ void Synchronizer::isSyncedExternally(unsigned int aAccountId, const QString aCl
     }
     qDeleteAll(syncProfiles);
 }
-

--- a/msyncd/synchronizer.cpp
+++ b/msyncd/synchronizer.cpp
@@ -1059,7 +1059,7 @@ void Synchronizer::initializeScheduler()
         connect(iSyncScheduler, SIGNAL(syncNow(QString)),
                 this, SLOT(startScheduledSync(QString)), Qt::QueuedConnection);
         connect(iSyncScheduler, SIGNAL(externalSyncChanged(QString, bool)),
-                this, SLOT(externalSyncStatus(QString, bool)), Qt::QueuedConnection);
+                this, SLOT(reportExternalSyncStatus(QString, bool)), Qt::QueuedConnection);
         QList<SyncProfile *> profiles = iProfileManager.allSyncProfiles();
         foreach (SyncProfile *profile, profiles) {
             if (profile->syncType() == SyncProfile::SYNC_SCHEDULED) {
@@ -1069,7 +1069,7 @@ void Synchronizer::initializeScheduler()
             // on startup, in case of a crash/abort of this
             // process, we should update pontential listeners with
             // the correct status
-            externalSyncStatus(profile, true);
+            reportExternalSyncStatus(profile, true);
         }
         qDeleteAll(profiles);
     }
@@ -1459,7 +1459,7 @@ void Synchronizer::reschedule(const QString &aProfileName)
         iSyncScheduler->removeProfile(aProfileName);
     }
     if (profile) {
-        externalSyncStatus(profile);
+        reportExternalSyncStatus(profile);
         qCDebug(lcButeoMsyncd) << "Reschdule profile" << aProfileName << profile->syncType() << profile->isEnabled();
         delete profile;
         profile = nullptr;
@@ -1519,7 +1519,7 @@ void Synchronizer::removeScheduledSync(const QString &aProfileName)
         }
         // Check if external sync status changed, profile might be turned
         // to sync externally and thus buteo sync set to disable
-        externalSyncStatus(profile);
+        reportExternalSyncStatus(profile);
         delete profile;
     }
 }
@@ -1561,13 +1561,13 @@ void Synchronizer::backupRestoreStarts()
     delete iSyncScheduler;
     iSyncScheduler = 0;
 
-    // Request all external syncs to stop, relying on externalSyncStatus() to
+    // Request all external syncs to stop, relying on reportExternalSyncStatus() to
     // act appropriately because (getBackUpRestoreState() == true)
     QMap<QString, bool>::iterator syncStatus;
     for (syncStatus = iExternalSyncProfileStatus.begin();
             syncStatus != iExternalSyncProfileStatus.end(); ++syncStatus) {
         const QString &profileName = syncStatus.key();
-        externalSyncStatus(profileName, false);
+        reportExternalSyncStatus(profileName, false);
     }
 }
 
@@ -1909,11 +1909,11 @@ QString Synchronizer::getValue(const QString &aAddress, const QString &aKey)
     return value;
 }
 
-void Synchronizer::externalSyncStatus(const QString &aProfileName, bool aQuery)
+void Synchronizer::reportExternalSyncStatus(const QString &aProfileName, bool force)
 {
     SyncProfile *profile = iProfileManager.syncProfile(aProfileName);
     if (profile) {
-        externalSyncStatus(profile, aQuery);
+        reportExternalSyncStatus(profile, force);
         delete profile;
     }
 }
@@ -1922,7 +1922,7 @@ void Synchronizer::externalSyncStatus(const QString &aProfileName, bool aQuery)
 // containing the client profile name, since those are always associated with a
 // specific plugin, this way potential listeners of these signals can distinguish the signals
 // based on the accountId and client profile name.
-void Synchronizer::externalSyncStatus(const SyncProfile *aProfile, bool aQuery)
+void Synchronizer::reportExternalSyncStatus(const SyncProfile *aProfile, bool force)
 {
     int accountId = aProfile->key(KEY_ACCOUNT_ID).toInt();
     if (accountId) {
@@ -1931,7 +1931,7 @@ void Synchronizer::externalSyncStatus(const SyncProfile *aProfile, bool aQuery)
 
         // All external syncs are stopped while a backup or restore is running
         if (getBackUpRestoreState()) {
-            if (iExternalSyncProfileStatus.value(profileName) || aQuery) {
+            if (iExternalSyncProfileStatus.value(profileName) || force) {
                 qCDebug(lcButeoMsyncd) << "Sync externally status suspended during backup for profile:" << profileName;
                 iExternalSyncProfileStatus.insert(profileName, false);
                 emit syncedExternallyStatus(accountId, clientProfile, false);
@@ -1942,7 +1942,7 @@ void Synchronizer::externalSyncStatus(const SyncProfile *aProfile, bool aQuery)
                 qCDebug(lcButeoMsyncd) << "Sync externally status changed from false to true for profile:" << profileName;
                 iExternalSyncProfileStatus.insert(profileName, true);
                 emit syncedExternallyStatus(accountId, clientProfile, true);
-            } else if (aQuery) {
+            } else if (force) {
                 qCDebug(lcButeoMsyncd) << "Account is in set to sync externally for profile:" << profileName;
                 emit syncedExternallyStatus(accountId, clientProfile, true);
             }
@@ -1957,7 +1957,7 @@ void Synchronizer::externalSyncStatus(const SyncProfile *aProfile, bool aQuery)
                     iExternalSyncProfileStatus.insert(profileName, isSyncExternally);
                     qCDebug(lcButeoMsyncd) << "Sync externally status changed to " << isSyncExternally << "for profile:" << profileName;
                     emit syncedExternallyStatus(accountId, clientProfile, isSyncExternally);
-                } else if (aQuery) {
+                } else if (force) {
                     qCDebug(lcButeoMsyncd) << "Sync externally status did not change, current state is: " << prevSyncExtState << "for profile:" <<
                               profileName;
                     emit syncedExternallyStatus(accountId, clientProfile, prevSyncExtState);
@@ -1972,7 +1972,7 @@ void Synchronizer::externalSyncStatus(const SyncProfile *aProfile, bool aQuery)
                 iExternalSyncProfileStatus.remove(profileName);
                 emit syncedExternallyStatus(accountId, clientProfile, false);
                 qCDebug(lcButeoMsyncd) << "Removing sync externally status for profile:" << profileName;
-            } else if (aQuery) {
+            } else if (force) {
                 qCDebug(lcButeoMsyncd) << "Sync externally is off for profile:" << profileName;
                 emit syncedExternallyStatus(accountId, clientProfile, false);
             }
@@ -2036,7 +2036,7 @@ void Synchronizer::isSyncedExternally(unsigned int aAccountId, const QString aCl
     if (!syncProfiles.isEmpty()) {
         foreach (SyncProfile *profile, syncProfiles) {
             if (profile->clientProfile()->name() == aClientProfileName) {
-                externalSyncStatus(profile, true);
+                reportExternalSyncStatus(profile, true);
                 profileFound = true;
                 break;
             }

--- a/msyncd/synchronizer.h
+++ b/msyncd/synchronizer.h
@@ -68,8 +68,8 @@ class Synchronizer : public SyncDBusInterface, // Derived from QObject
     public PluginCbInterface
 {
     Q_OBJECT
-public:
 
+public:
     /// \brief The contructor.
     Synchronizer(QCoreApplication *aApplication);
 
@@ -114,7 +114,6 @@ public:
 // --------------------------------------------------------------------------
 
 public slots:
-
     //! \see SyncDBusInterface::startSync
     virtual bool startSync(QString aProfileName);
 
@@ -231,7 +230,6 @@ public slots:
     void isSyncedExternally(unsigned int aAccountId, const QString aClientProfileName);
 
 signals:
-
     //! emitted by releaseStorages call
     void storageReleased();
 
@@ -243,7 +241,6 @@ signals:
     void syncDone(const QString &aProfileName);
 
 private slots:
-
     /*! \brief Handler for storage released signal.
      *
      * Tries to start the next sync in queue, which may have been blocked
@@ -324,7 +321,6 @@ private slots:
     void profileChangeTriggerTimeout();
 
 private:
-
     bool startSync(const QString &aProfileName, bool aScheduled);
 
     /*! \brief Starts a sync with the given profile.

--- a/msyncd/synchronizer.h
+++ b/msyncd/synchronizer.h
@@ -313,9 +313,9 @@ private slots:
     /*! \brief Handles externalSyncChanged signal
      *
      * @param aProfileName Name of the profile
-     * @param aQuery When true 'syncedExternallyStatus' dbus signal will be emitted even if the state did not change.
+     * @param force When true 'syncedExternallyStatus' dbus signal will be emitted even if the state did not change.
      */
-    void externalSyncStatus(const QString &aProfileName, bool aQuery);
+    void reportExternalSyncStatus(const QString &aProfileName, bool force);
 
     /*! \brief Triggers sync for profiles which were queued for sync due to profile changes. */
     void profileChangeTriggerTimeout();
@@ -401,9 +401,9 @@ private:
      * will be emitted to notify possible clients.
      *
      * @param aProfile the profile that the state will be checked
-     * @param aQuery When true 'syncedExternallyStatus' dbus signal will be emitted even if the state did not change.
+     * @param force When true 'syncedExternallyStatus' dbus signal will be emitted even if the state did not change.
      */
-    void externalSyncStatus(const SyncProfile *aProfile, bool aQuery = false);
+    void reportExternalSyncStatus(const SyncProfile *aProfile, bool force = false);
 
     QMap<QString, SyncSession *> iActiveSessions;
     QMap<QString, bool> iExternalSyncProfileStatus;

--- a/oopp-runner/PluginCbImpl.h
+++ b/oopp-runner/PluginCbImpl.h
@@ -33,7 +33,6 @@ class PluginCbImpl : public PluginCbInterface
 {
 public:
     PluginCbImpl();
-
     ~PluginCbImpl();
 
     /// \see PluginCbInterface::requestStorage
@@ -60,16 +59,12 @@ public:
     virtual QString getValue(const QString &aAddress, const QString &aKey);
 
 signals:
-
     //! emitted by releaseStorages call
     void storageReleased();
 
 private:
-
     SyncDaemonProxy  *imsyncIface;
-
     PluginManager   iPluginManager;
-
     TransportTracker  iTransportTracker;
 };
 


### PR DESCRIPTION
Encountered this externalSyncStatus() while checking @dcaliste PR on messagingframework. Was confusingly sounding like a getter and the "query" parameter made little sense for the actual meaning so did some renaming.

Still don't like the related "isSyncedExternally" d-bus method which doesn't return anything but emits a d-bus status signal via this code. But adjusting involves D-Bus API and whatnot so just doing the simpler thing now.