### PR TITLE
Remove coverage target

### DIFF
--- a/buteo-sync.pro
+++ b/buteo-sync.pro
@@ -12,7 +12,3 @@ declarative.depends = libbuteosyncfw
 msyncd.depends = libbuteosyncfw
 oopp-runner.depends = libbuteosyncfw
 unittests.depends = libbuteosyncfw msyncd
-
-coverage.CONFIG += recursive
-
-QMAKE_EXTRA_TARGETS += coverage

--- a/libbuteosyncfw/libbuteosyncfw.pro
+++ b/libbuteosyncfw/libbuteosyncfw.pro
@@ -116,30 +116,3 @@ QMAKE_PKGCONFIG_LIBDIR  = $$target.path
 QMAKE_PKGCONFIG_INCDIR  = $$headers.path
 QMAKE_PKGCONFIG_VERSION = $$VERSION
 pkgconfig.files = $${TARGET}.pc
-
-# #####################################################################
-# make coverage (debug)
-# #####################################################################
-coverage.CONFIG += recursive
-QMAKE_EXTRA_TARGETS += coverage
-CONFIG(debug,debug|release){
-    QMAKE_EXTRA_TARGETS += cov_cxxflags \
-                          cov_lflags
-    cov_cxxflags.target = coverage
-    cov_cxxflags.depends = CXXFLAGS \
-         += \
-        -fprofile-arcs \
-        -ftest-coverage
-    cov_lflags.target = coverage
-    cov_lflags.depends = LFLAGS \
-        += \
-        -fprofile-arcs \
-        -ftest-coverage
-
-    coverage.commands = @echo \
-        "Built with coverage support..."
-    build_pass|!debug_and_release : coverage.depends = all
-    QMAKE_CLEAN += $(OBJECTS_DIR)/*.gcda \
-        $(OBJECTS_DIR)/*.gcno \
-        $(OBJECTS_DIR)/*.gcov
-}

--- a/msyncd/AccountsHelper.cpp
+++ b/msyncd/AccountsHelper.cpp
@@ -334,14 +334,14 @@ void AccountsHelper::registerAccountListener(Accounts::AccountId id)
     // Initialisation and callback for account enabled/disabled
     syncEnableWithAccount(account);
     QObject::connect(account, &Accounts::Account::enabledChanged,
-    [this, account] (const QString & serviceName, bool enabled) {
+                     [this, account] (const QString & serviceName, bool enabled) {
         qCDebug(lcButeoMsyncd) << "Received account enabled changed signal" << serviceName << enabled << account->displayName();
         syncEnableWithAccount(account);
     });
 
 #ifndef USE_ACCOUNTSHELPER_SCHEDULER_WATCHER
     qCDebug(lcButeoMsyncd) << "AccountsHelper::registerAccountListener() is disabled!  Not listening to scheduler change signals for account:"
-              << id;
+                           << id;
 #else
     // Account SyncOnChange
     QList<SyncProfile *> profiles = getProfilesByAccountId(id);

--- a/msyncd/BackgroundSync.cpp
+++ b/msyncd/BackgroundSync.cpp
@@ -175,7 +175,6 @@ QString BackgroundSync::getProfNameFromId(const QString activityId) const
 
 BackgroundActivity::Frequency BackgroundSync::frequencyFromSeconds(int seconds)
 {
-
     // Don't allow frequencies smaller than 5 mins.
     // In rare cases is possible that seconds is 0
     int minutes = seconds / 60;

--- a/msyncd/ServerActivator.cpp
+++ b/msyncd/ServerActivator.cpp
@@ -29,9 +29,9 @@ using namespace Buteo;
 
 ServerActivator::ServerActivator(ProfileManager &aProfileManager,
                                  TransportTracker &aTransportTracker, QObject *aParent)
-    :   QObject(aParent),
-        iProfileManager(aProfileManager),
-        iTransportTracker(aTransportTracker)
+    : QObject(aParent)
+    , iProfileManager(aProfileManager)
+    , iTransportTracker(aTransportTracker)
 {
     FUNCTION_CALL_TRACE(lcButeoTrace);
 

--- a/msyncd/ServerPluginRunner.cpp
+++ b/msyncd/ServerPluginRunner.cpp
@@ -33,11 +33,11 @@ using namespace Buteo;
 ServerPluginRunner::ServerPluginRunner(const QString &aPluginName,
                                        Profile *aProfile, PluginManager *aPluginMgr, PluginCbInterface *aPluginCbIf,
                                        ServerActivator *aServerActivator, QObject *aParent)
-    :   PluginRunner(PLUGIN_SERVER, aPluginName, aPluginMgr, aPluginCbIf, aParent),
-        iProfile(aProfile),
-        iPlugin(0),
-        iThread(0),
-        iServerActivator(aServerActivator)
+    : PluginRunner(PLUGIN_SERVER, aPluginName, aPluginMgr, aPluginCbIf, aParent)
+    , iProfile(aProfile)
+    , iPlugin(0)
+    , iThread(0)
+    , iServerActivator(aServerActivator)
 {
     FUNCTION_CALL_TRACE(lcButeoTrace);
 }
@@ -90,9 +90,10 @@ bool ServerPluginRunner::init()
 
     // Connect signals from the plug-in.
 
-    connect(iPlugin, SIGNAL(transferProgress(const QString &, Sync::TransferDatabase, Sync::TransferType, const QString &,
-                                             int)),
-            this, SLOT(onTransferProgress(const QString &, Sync::TransferDatabase, Sync::TransferType, const QString &, int)));
+    connect(iPlugin,
+            SIGNAL(transferProgress(const QString &, Sync::TransferDatabase, Sync::TransferType, const QString &, int)),
+            this,
+            SLOT(onTransferProgress(const QString &, Sync::TransferDatabase, Sync::TransferType, const QString &, int)));
 
     connect(iPlugin, &ServerPlugin::error, this, &ServerPluginRunner::onError);
 

--- a/msyncd/ServerThread.cpp
+++ b/msyncd/ServerThread.cpp
@@ -30,8 +30,8 @@ using namespace Buteo;
 
 
 ServerThread::ServerThread()
-    :  iServerPlugin(0),
-       iRunning(false)
+    : iServerPlugin(0)
+    , iRunning(false)
 {
     FUNCTION_CALL_TRACE(lcButeoTrace);
 }

--- a/msyncd/StorageBooker.cpp
+++ b/msyncd/StorageBooker.cpp
@@ -27,7 +27,7 @@
 using namespace Buteo;
 
 StorageBooker::StorageBooker()
-    :   iMutex(QMutex::Recursive)
+    : iMutex(QMutex::Recursive)
 {
     FUNCTION_CALL_TRACE(lcButeoTrace);
 }

--- a/msyncd/SyncAlarmInventory.cpp
+++ b/msyncd/SyncAlarmInventory.cpp
@@ -34,10 +34,10 @@ const QString ALARM_CONNECTION_NAME("alarms");
 
 const int TRIGGER_COUNT = 1;
 
-SyncAlarmInventory::SyncAlarmInventory():
-    iTimer(0),
-    currentAlarm(0),
-    triggerCount(TRIGGER_COUNT)
+SyncAlarmInventory::SyncAlarmInventory()
+    : iTimer(0)
+    , currentAlarm(0)
+    , triggerCount(TRIGGER_COUNT)
 {
     // empty.explicitly call init
 }

--- a/msyncd/SyncBackup.cpp
+++ b/msyncd/SyncBackup.cpp
@@ -32,10 +32,10 @@ using namespace Buteo;
 
 static const char *DBUS_BACKUP_OBJECT = "/backup";
 
-SyncBackup::SyncBackup() :
-    iBackupRestore(false),
-    iReply(0),
-    iAdaptor(0)
+SyncBackup::SyncBackup()
+    : iBackupRestore(false)
+    , iReply(0)
+    , iAdaptor(0)
 {
     FUNCTION_CALL_TRACE(lcButeoTrace);
 

--- a/msyncd/SyncOnChange.cpp
+++ b/msyncd/SyncOnChange.cpp
@@ -6,9 +6,9 @@
 
 using namespace Buteo;
 
-SyncOnChange::SyncOnChange() :
-    iStorageChangeNotifier(new StorageChangeNotifier()),
-    iSOCScheduler(0)
+SyncOnChange::SyncOnChange()
+    : iStorageChangeNotifier(new StorageChangeNotifier())
+    , iSOCScheduler(0)
 {
     FUNCTION_CALL_TRACE(lcButeoTrace);
 }

--- a/msyncd/SyncScheduler.cpp
+++ b/msyncd/SyncScheduler.cpp
@@ -36,7 +36,7 @@
 using namespace Buteo;
 
 SyncScheduler::SyncScheduler(QObject *aParent)
-    :   QObject(aParent)
+    : QObject(aParent)
 {
     FUNCTION_CALL_TRACE(lcButeoTrace);
 

--- a/msyncd/SyncSession.cpp
+++ b/msyncd/SyncSession.cpp
@@ -31,19 +31,19 @@
 using namespace Buteo;
 
 SyncSession::SyncSession(SyncProfile *aProfile, QObject *aParent)
-    :   QObject(aParent),
-        iProfile(aProfile),
-        iPluginRunner(0),
-        iStatus(Sync::SYNC_ERROR),
-        iErrorCode(SyncResults::NO_ERROR),
-        iPluginRunnerOwned(false),
-        iScheduled(false),
-        iAborted(false),
-        iStarted(false),
-        iFinished(false),
-        iCreateProfile(false),
-        iStorageBooker(0),
-        iNetworkManager(0)
+    : QObject(aParent)
+    , iProfile(aProfile)
+    , iPluginRunner(0)
+    , iStatus(Sync::SYNC_ERROR)
+    , iErrorCode(SyncResults::NO_ERROR)
+    , iPluginRunnerOwned(false)
+    , iScheduled(false)
+    , iAborted(false)
+    , iStarted(false)
+    , iFinished(false)
+    , iCreateProfile(false)
+    , iStorageBooker(0)
+    , iNetworkManager(0)
 {
     FUNCTION_CALL_TRACE(lcButeoTrace);
 }

--- a/msyncd/msyncd-app.pro
+++ b/msyncd/msyncd-app.pro
@@ -52,33 +52,3 @@ INSTALLS += target \
     syncwidget \
     service \
     gschemas
-
-# #####################################################################
-# make coverage (debug)
-# #####################################################################
-coverage.CONFIG += recursive
-QMAKE_EXTRA_TARGETS += coverage
-CONFIG(debug,debug|release) {
-    QMAKE_EXTRA_TARGETS += cov_cxxflags \
-        cov_lflags
-    cov_cxxflags.target = coverage
-    cov_cxxflags.depends = CXXFLAGS \
-        += \
-        -fprofile-arcs \
-        -ftest-coverage
-    cov_lflags.target = coverage
-    cov_lflags.depends = LFLAGS \
-        += \
-        -fprofile-arcs \
-        -ftest-coverage
-
-    # QMAKE_CXXFLAGS += -fprofile-arcs -ftest-coverage
-    # QMAKE_LFLAGS += -fprofile-arcs -ftest-coverage
-    # -ftest-coverage
-    coverage.commands = @echo \
-        "Built with coverage support..."
-    build_pass|!debug_and_release:coverage.depends = all
-    QMAKE_CLEAN += $(OBJECTS_DIR)/*.gcda \
-        $(OBJECTS_DIR)/*.gcno \
-        $(OBJECTS_DIR)/*.gcov
-}

--- a/msyncd/msyncd-lib.pro
+++ b/msyncd/msyncd-lib.pro
@@ -101,33 +101,3 @@ contains(DEFINES, USE_KEEPALIVE) {
         IPHeartBeat.cpp \
         SyncAlarmInventory.cpp
 }
-
-# #####################################################################
-# make coverage (debug)
-# #####################################################################
-coverage.CONFIG += recursive
-QMAKE_EXTRA_TARGETS += coverage
-CONFIG(debug,debug|release) {
-    QMAKE_EXTRA_TARGETS += cov_cxxflags \
-        cov_lflags
-    cov_cxxflags.target = coverage
-    cov_cxxflags.depends = CXXFLAGS \
-        += \
-        -fprofile-arcs \
-        -ftest-coverage
-    cov_lflags.target = coverage
-    cov_lflags.depends = LFLAGS \
-        += \
-        -fprofile-arcs \
-        -ftest-coverage
-
-    # QMAKE_CXXFLAGS += -fprofile-arcs -ftest-coverage
-    # QMAKE_LFLAGS += -fprofile-arcs -ftest-coverage
-    # -ftest-coverage
-    coverage.commands = @echo \
-        "Built with coverage support..."
-    build_pass|!debug_and_release:coverage.depends = all
-    QMAKE_CLEAN += $(OBJECTS_DIR)/*.gcda \
-        $(OBJECTS_DIR)/*.gcno \
-        $(OBJECTS_DIR)/*.gcov
-}

--- a/msyncd/msyncd.pro
+++ b/msyncd/msyncd.pro
@@ -1,9 +1,3 @@
 TEMPLATE = subdirs
 CONFIG += ordered
 SUBDIRS = msyncd-lib.pro msyncd-app.pro
-
-# #####################################################################
-# make coverage (debug)
-# #####################################################################
-coverage.CONFIG += recursive
-QMAKE_EXTRA_TARGETS += coverage

--- a/unittests/dummyplugins/dummyclient/dummyclient.pro
+++ b/unittests/dummyplugins/dummyclient/dummyclient.pro
@@ -10,46 +10,13 @@ INCLUDEPATH += . \
 QT -= gui
 CONFIG += plugin
 
-#input
 HEADERS += DummyClient.h
 
 SOURCES += DummyClient.cpp
 
 #clean
 QMAKE_CLEAN += $(TARGET) $(TARGET0) $(TARGET1) $(TARGET2)
-QMAKE_CLEAN += $(OBJECTS_DIR)/*.gcda $(OBJECTS_DIR)/*.gcno $(OBJECTS_DIR)/*.gcov $(OBJECTS_DIR)/moc_*
+QMAKE_CLEAN += $(OBJECTS_DIR)/moc_*
 
 target.path = /opt/tests/buteo-syncfw
 INSTALLS += target
-
-
-# #####################################################################
-# make coverage (debug)
-# #####################################################################
-coverage.CONFIG += recursive
-QMAKE_EXTRA_TARGETS += coverage
-CONFIG(debug,debug|release){
-    QMAKE_EXTRA_TARGETS += cov_cxxflags \
-                        cov_lflags
-
-    cov_cxxflags.target = coverage
-    cov_cxxflags.depends = CXXFLAGS \
-         += \
-        -fprofile-arcs \
-        -ftest-coverage
-
-    cov_lflags.target = coverage
-    cov_lflags.depends = LFLAGS \
-        += \
-        -fprofile-arcs \
-        -ftest-coverage
-
-    coverage.commands = @echo \
-        "Built with coverage support..."
-
-    build_pass|!debug_and_release : coverage.depends = all
-
-    QMAKE_CLEAN += $(OBJECTS_DIR)/*.gcda \
-        $(OBJECTS_DIR)/*.gcno \
-        $(OBJECTS_DIR)/*.gcov
-}

--- a/unittests/dummyplugins/dummyplugins.pro
+++ b/unittests/dummyplugins/dummyplugins.pro
@@ -3,34 +3,3 @@ TEMPLATE = subdirs
 SUBDIRS += dummyclient \
            dummyserver \
            dummystorage
-
-# #####################################################################
-# make coverage (debug)
-# #####################################################################
-coverage.CONFIG += recursive
-QMAKE_EXTRA_TARGETS += coverage
-CONFIG(debug,debug|release){
-    QMAKE_EXTRA_TARGETS += cov_cxxflags \
-			cov_lflags
-
-    cov_cxxflags.target = coverage
-    cov_cxxflags.depends = CXXFLAGS \
-         += \
-        -fprofile-arcs \
-        -ftest-coverage
-
-    cov_lflags.target = coverage
-    cov_lflags.depends = LFLAGS \
-        += \
-        -fprofile-arcs \
-	-ftest-coverage
-
-    coverage.commands = @echo \
-        "Built with coverage support..."
-
-    build_pass|!debug_and_release : coverage.depends = all
-
-    QMAKE_CLEAN += $(OBJECTS_DIR)/*.gcda \
-        $(OBJECTS_DIR)/*.gcno \
-        $(OBJECTS_DIR)/*.gcov
-}

--- a/unittests/dummyplugins/dummyserver/dummyserver.pro
+++ b/unittests/dummyplugins/dummyserver/dummyserver.pro
@@ -17,38 +17,7 @@ SOURCES += DummyServer.cpp
 
 #clean
 QMAKE_CLEAN += $(TARGET) $(TARGET0) $(TARGET1) $(TARGET2)
-QMAKE_CLEAN += $(OBJECTS_DIR)/*.gcda $(OBJECTS_DIR)/*.gcno $(OBJECTS_DIR)/*.gcov $(OBJECTS_DIR)/moc_*
+QMAKE_CLEAN += $(OBJECTS_DIR)/moc_*
 
 target.path = /opt/tests/buteo-syncfw/
 INSTALLS += target
-
-# #####################################################################
-# make coverage (debug)
-# #####################################################################
-coverage.CONFIG += recursive
-QMAKE_EXTRA_TARGETS += coverage
-CONFIG(debug,debug|release){
-    QMAKE_EXTRA_TARGETS += cov_cxxflags \
-                        cov_lflags
-
-    cov_cxxflags.target = coverage
-    cov_cxxflags.depends = CXXFLAGS \
-         += \
-        -fprofile-arcs \
-        -ftest-coverage
-
-    cov_lflags.target = coverage
-    cov_lflags.depends = LFLAGS \
-        += \
-        -fprofile-arcs \
-        -ftest-coverage
-
-    coverage.commands = @echo \
-        "Built with coverage support..."
-
-    build_pass|!debug_and_release : coverage.depends = all
-
-    QMAKE_CLEAN += $(OBJECTS_DIR)/*.gcda \
-        $(OBJECTS_DIR)/*.gcno \
-        $(OBJECTS_DIR)/*.gcov
-}

--- a/unittests/dummyplugins/dummystorage/dummystorage.pro
+++ b/unittests/dummyplugins/dummystorage/dummystorage.pro
@@ -17,39 +17,7 @@ SOURCES += DummyStorage.cpp
 
 #clean
 QMAKE_CLEAN += $(TARGET) $(TARGET0) $(TARGET1) $(TARGET2)
-QMAKE_CLEAN += $(OBJECTS_DIR)/*.gcda $(OBJECTS_DIR)/*.gcno $(OBJECTS_DIR)/*.gcov $(OBJECTS_DIR)/moc_*
+QMAKE_CLEAN += $(OBJECTS_DIR)/moc_*
 
 target.path = /opt/tests/buteo-syncfw/
 INSTALLS += target
-
-
-# #####################################################################
-# make coverage (debug)
-# #####################################################################
-coverage.CONFIG += recursive
-QMAKE_EXTRA_TARGETS += coverage
-CONFIG(debug,debug|release){
-    QMAKE_EXTRA_TARGETS += cov_cxxflags \
-                        cov_lflags
-
-    cov_cxxflags.target = coverage
-    cov_cxxflags.depends = CXXFLAGS \
-         += \
-        -fprofile-arcs \
-        -ftest-coverage
-
-    cov_lflags.target = coverage
-    cov_lflags.depends = LFLAGS \
-        += \
-        -fprofile-arcs \
-        -ftest-coverage
-
-    coverage.commands = @echo \
-        "Built with coverage support..."
-
-    build_pass|!debug_and_release : coverage.depends = all
-
-    QMAKE_CLEAN += $(OBJECTS_DIR)/*.gcda \
-        $(OBJECTS_DIR)/*.gcno \
-        $(OBJECTS_DIR)/*.gcov
-}

--- a/unittests/tests/msyncdtests/msyncdtests.pro
+++ b/unittests/tests/msyncdtests/msyncdtests.pro
@@ -20,6 +20,3 @@ SUBDIRS += \
         IPHeartBeatTest \
         SyncSchedulerTest \
 }
-
-coverage.CONFIG += recursive
-QMAKE_EXTRA_TARGETS += coverage

--- a/unittests/tests/pluginmanagertests/pluginmanagertests.pro
+++ b/unittests/tests/pluginmanagertests/pluginmanagertests.pro
@@ -4,6 +4,3 @@ SUBDIRS = \
         DeletedItemsIdStorageTest \
         ServerPluginTest \
         StoragePluginTest \
-
-coverage.CONFIG += recursive
-QMAKE_EXTRA_TARGETS += coverage

--- a/unittests/tests/syncfwclienttests/syncfwclienttests.pro
+++ b/unittests/tests/syncfwclienttests/syncfwclienttests.pro
@@ -1,6 +1,3 @@
 TEMPLATE = subdirs
 SUBDIRS = \
         SyncClientInterfaceTest \
-
-coverage.CONFIG += recursive
-QMAKE_EXTRA_TARGETS += coverage

--- a/unittests/tests/tests_common.pri
+++ b/unittests/tests/tests_common.pri
@@ -18,8 +18,6 @@ CONFIG += link_pkgconfig link_prl
 
 PKGCONFIG += dbus-1
 
-LIBS += -lgcov
-
 LIBS += -L$${OUT_PWD}/$${tests_subdir_r}/../../libbuteosyncfw
 
 PKGCONFIG += libsignon-qt5 accounts-qt5
@@ -30,11 +28,6 @@ LIBS += -lbuteosyncfw5
 QMAKE_LIBDIR_QT = $${OUT_PWD}/$${tests_subdir_r}/../../libbuteosyncfw
 
 DEFINES += SYNCFW_UNIT_TESTS
-
-QMAKE_CXXFLAGS += -Wall \
-        -fprofile-arcs \
-        -ftest-coverage \
-         -g -O0
 
 INCLUDEPATH = \
     $${PWD} \
@@ -55,31 +48,5 @@ DEPENDPATH = \
 
 INSTALL_TESTDIR = /opt/tests/buteo-syncfw
 INSTALL_TESTDATADIR = $${INSTALL_TESTDIR}/data
-
-# #####################################################################
-# make coverage (debug)
-# #####################################################################
-coverage.CONFIG += recursive
-QMAKE_EXTRA_TARGETS += coverage
-CONFIG(debug,debug|release) {
-    QMAKE_EXTRA_TARGETS += cov_cxxflags \
-        cov_lflags
-    cov_cxxflags.target = coverage
-    cov_cxxflags.depends = CXXFLAGS \
-        += \
-        -fprofile-arcs \
-        -ftest-coverage
-    cov_lflags.target = coverage
-    cov_lflags.depends = LFLAGS \
-        += \
-        -fprofile-arcs \
-        -ftest-coverage
-    coverage.commands = @echo \
-        "Built with coverage support..."
-    build_pass|!debug_and_release:coverage.depends = all
-    QMAKE_CLEAN += $(OBJECTS_DIR)/*.gcda \
-        $(OBJECTS_DIR)/*.gcno \
-        $(OBJECTS_DIR)/*.gcov
-}
 
 }

--- a/unittests/unittests.pro
+++ b/unittests/unittests.pro
@@ -1,7 +1,3 @@
 TEMPLATE = subdirs
 SUBDIRS += dummyplugins \
            tests
-
-coverage.CONFIG += recursive
-
-QMAKE_EXTRA_TARGETS += coverage


### PR DESCRIPTION
Main commit 

    [buteo-syncfw] Remove coverage target. JB#63233
    
    There's been some reproducibility problems that have slightly hinted
    towards the coverage compilation option.
    
    In practice don't think we've ever used this in sailfish context
    and I doubt anyone has even tested that the setup works anymore.
    We don't either have a fixation on aiming to have 100% unit test coverage.
    
    So let's just remove, it cleans up the build setup too.
