### PR TITLE
[buteo-syncfw] Build without usb-moded. JB#39455

### DIFF
--- a/rpm/buteo-syncfw-qt5.spec
+++ b/rpm/buteo-syncfw-qt5.spec
@@ -73,7 +73,7 @@ Summary: QML plugin for %{name}
 
 
 %build
-%qmake5 -recursive "VERSION=%{version}" CONFIG+=usb-moded DEFINES+=USE_KEEPALIVE
+%qmake5 -recursive "VERSION=%{version}" DEFINES+=USE_KEEPALIVE
 %make_build
 make doc %{_smp_mflags}
 


### PR DESCRIPTION
Hasn't been used for anything in long time. Only remaining usage I'm spotting is SyncML in buteo-sync-plugins which isn't used in sailfish.

Could consider even dropping, but the related code is mostly nicely in its own corner so doesn't harm much just keeping it for now.