### PR TITLE
fix backup scheduling

### DIFF
--- a/libbuteosyncfw/profile/ProfileEngineDefs.h
+++ b/libbuteosyncfw/profile/ProfileEngineDefs.h
@@ -52,6 +52,10 @@ const QString ATTR_MINOR_CODE("minorcode");
 const QString ATTR_ENABLED("enabled");
 const QString ATTR_SYNC_CONFIGURE("syncconfiguredtime");
 const QString ATTR_EXTERNAL_SYNC("externalsync");
+// Optional per-schedule acceptance window (in seconds) for explicit-time wakeups.
+// Allows widening the default tolerance to accommodate imprecise platform wakeup
+// timers (e.g. nemo-keepalive BackgroundActivity frequency buckets).
+const QString ATTR_WAKEUP_TOLERANCE("wakeuptolerance");
 
 const QString TAG_FIELD("field");
 const QString TAG_PROFILE("profile");

--- a/libbuteosyncfw/profile/SyncSchedule.cpp
+++ b/libbuteosyncfw/profile/SyncSchedule.cpp
@@ -59,6 +59,7 @@ SyncSchedulePrivate::SyncSchedulePrivate(const SyncSchedulePrivate &aSource)
     , iRushEnabled(aSource.iRushEnabled)
     , iExternalRushEnabled(aSource.iExternalRushEnabled)
 {
+    iWakeupTolerance = aSource.iWakeupTolerance;
 }
 
 SyncSchedule::SyncSchedule()
@@ -79,6 +80,11 @@ SyncSchedule::SyncSchedule(const QDomElement &aRoot)
     d_ptr->iEnabled = (aRoot.attribute(ATTR_ENABLED) == BOOLEAN_TRUE);
     d_ptr->iDays = d_ptr->parseDays(aRoot.attribute(ATTR_DAYS));
     d_ptr->iScheduleConfiguredTime = QDateTime::fromString(aRoot.attribute(ATTR_SYNC_CONFIGURE), Qt::ISODate);
+
+    // Optional per-schedule wakeup tolerance; 0 (or missing) means "use default".
+    if (aRoot.hasAttribute(ATTR_WAKEUP_TOLERANCE)) {
+        d_ptr->iWakeupTolerance = aRoot.attribute(ATTR_WAKEUP_TOLERANCE).toUInt();
+    }
 
     QDomElement rush = aRoot.firstChildElement(TAG_RUSH);
 
@@ -124,7 +130,8 @@ bool SyncSchedule::operator==(const SyncSchedule &aRhs) const
            && (d_ptr->iInterval == aRhs.d_ptr->iInterval)
            && (d_ptr->iEnabled == aRhs.d_ptr->iEnabled)
            && (d_ptr->iRushEnabled == aRhs.d_ptr->iRushEnabled)
-           && (d_ptr->iExternalRushEnabled == aRhs.d_ptr->iExternalRushEnabled);
+           && (d_ptr->iExternalRushEnabled == aRhs.d_ptr->iExternalRushEnabled)
+           && (d_ptr->iWakeupTolerance == aRhs.d_ptr->iWakeupTolerance);
 }
 
 QDomElement SyncSchedule::toXml(QDomDocument &aDoc) const
@@ -136,6 +143,11 @@ QDomElement SyncSchedule::toXml(QDomDocument &aDoc) const
     root.setAttribute(ATTR_INTERVAL, QString::number(d_ptr->iInterval));
     root.setAttribute(ATTR_DAYS, d_ptr->createDays(d_ptr->iDays));
     root.setAttribute(ATTR_SYNC_CONFIGURE, d_ptr->iScheduleConfiguredTime.toString(Qt::ISODate));
+
+    // Only serialize wakeup tolerance when explicitly set, to keep XML output backward-compatible.
+    if (d_ptr->iWakeupTolerance > 0) {
+        root.setAttribute(ATTR_WAKEUP_TOLERANCE, QString::number(d_ptr->iWakeupTolerance));
+    }
 
     QDomElement rush = aDoc.createElement(TAG_RUSH);
     rush.setAttribute(ATTR_ENABLED, d_ptr->iRushEnabled ? BOOLEAN_TRUE :
@@ -268,6 +280,16 @@ unsigned SyncSchedule::rushInterval() const
 void SyncSchedule::setRushInterval(unsigned aInterval)
 {
     d_ptr->iRushInterval = aInterval;
+}
+
+unsigned int SyncSchedule::wakeupTolerance() const
+{
+    return d_ptr->iWakeupTolerance;
+}
+
+void SyncSchedule::setWakeupTolerance(unsigned int aSeconds)
+{
+    d_ptr->iWakeupTolerance = aSeconds;
 }
 
 bool SyncSchedule::inExternalSyncRushPeriod(const QDateTime &aDateTime) const
@@ -501,7 +523,13 @@ bool SyncSchedule::isSyncScheduled(const QDateTime &aActualDateTime, const QDate
     if (d_ptr->iTime.isValid() && d_ptr->iDays != SyncSchedule::NoDays) {
         // Accept wakeups close to the schedule for today, and also for yesterday's schedule
         // when the timer crosses midnight.
-        static const qint64 toleranceSecs = 5 * 60;
+        // Default: 5 minutes (historical behavior). Profiles can opt into a wider window
+        // via SyncSchedule::setWakeupTolerance() / the "wakeuptolerance" XML attribute,
+        // which is useful for schedules running on imprecise platform wakeup buckets.
+        static const qint64 defaultToleranceSecs = 5 * 60;
+        const qint64 toleranceSecs = d_ptr->iWakeupTolerance > 0
+                                     ? static_cast<qint64>(d_ptr->iWakeupTolerance)
+                                     : defaultToleranceSecs;
         qint64 minDiffSecs = LLONG_MAX;
 
         const QDate today = aActualDateTime.date();

--- a/libbuteosyncfw/profile/SyncSchedule.cpp
+++ b/libbuteosyncfw/profile/SyncSchedule.cpp
@@ -523,13 +523,31 @@ bool SyncSchedule::isSyncScheduled(const QDateTime &aActualDateTime, const QDate
     if (d_ptr->iTime.isValid() && d_ptr->iDays != SyncSchedule::NoDays) {
         // Accept wakeups close to the schedule for today, and also for yesterday's schedule
         // when the timer crosses midnight.
-        // Default: 5 minutes (historical behavior). Profiles can opt into a wider window
-        // via SyncSchedule::setWakeupTolerance() / the "wakeuptolerance" XML attribute,
-        // which is useful for schedules running on imprecise platform wakeup buckets.
-        static const qint64 defaultToleranceSecs = 5 * 60;
+        //
+        // The default tolerance depends on the schedule shape:
+        //  * Explicit-time-only schedules (days + time, interval == 0) are routed
+        //    through nemo-keepalive's frequency buckets (up to TwentyFourHours).
+        //    Those buckets fire on system-aligned IPHB slots and can easily drift
+        //    by tens of minutes from the configured time, so a strict 5-minute
+        //    window causes the wakeup to be rejected and the schedule to stall
+        //    until the next manual trigger. Use a 2-hour window for this shape.
+        //  * All other schedules (interval-based, rush, ...) keep the historical
+        //    5-minute window because their wakeups are accurate.
+        //
+        // Profiles can always override this via SyncSchedule::setWakeupTolerance()
+        // / the "wakeuptolerance" XML attribute.
+        static const qint64 defaultIntervalToleranceSecs = 5 * 60;
+        static const qint64 defaultExplicitTimeToleranceSecs = 2 * 60 * 60;
+        const bool isExplicitTimeOnly = (d_ptr->iInterval == 0);
+        const qint64 defaultToleranceSecs = isExplicitTimeOnly
+                                            ? defaultExplicitTimeToleranceSecs
+                                            : defaultIntervalToleranceSecs;
         const qint64 toleranceSecs = d_ptr->iWakeupTolerance > 0
                                      ? static_cast<qint64>(d_ptr->iWakeupTolerance)
                                      : defaultToleranceSecs;
+        qCDebug(lcButeoCore) << "Scheduled check: effective tolerance" << toleranceSecs
+                             << "secs (configured=" << d_ptr->iWakeupTolerance
+                             << ", explicitTimeOnly=" << isExplicitTimeOnly << ")";
         qint64 minDiffSecs = LLONG_MAX;
 
         const QDate today = aActualDateTime.date();

--- a/libbuteosyncfw/profile/SyncSchedule.cpp
+++ b/libbuteosyncfw/profile/SyncSchedule.cpp
@@ -499,19 +499,50 @@ bool SyncSchedule::isSyncScheduled(const QDateTime &aActualDateTime, const QDate
 
     // Simple case, aDateTime is the defined sync time.
     if (d_ptr->iTime.isValid() && d_ptr->iDays != SyncSchedule::NoDays) {
-        /* Todo: this is to simple implementation for the case where
-           sync time is close to midnight and the day has changed
-           already when fired. */
-        if (!SyncSchedulePrivate::daysMatch(d_ptr->iDays,
-                                            aActualDateTime.date().dayOfWeek())) {
+        // Accept wakeups close to the schedule for today, and also for yesterday's schedule
+        // when the timer crosses midnight.
+        static const qint64 toleranceSecs = 5 * 60;
+        qint64 minDiffSecs = LLONG_MAX;
+
+        const QDate today = aActualDateTime.date();
+        const bool todayMatch = SyncSchedulePrivate::daysMatch(d_ptr->iDays, today.dayOfWeek());
+        if (todayMatch) {
+            qint64 diff = QDateTime(today, d_ptr->iTime).secsTo(aActualDateTime);
+            if (diff < 0) {
+                diff = -diff;
+            }
+            minDiffSecs = qMin(minDiffSecs, diff);
+            qCDebug(lcButeoCore) << "Scheduled check (today): scheduled=" << QDateTime(today, d_ptr->iTime)
+                                 << "actual=" << aActualDateTime << "diffSecs=" << diff;
+        } else {
+            qCDebug(lcButeoCore) << "Scheduled check (today): day mismatch, scheduledDays=" << d_ptr->iDays
+                                 << "actualDayOfWeek=" << today.dayOfWeek();
+        }
+
+        const QDate yesterday = today.addDays(-1);
+        const bool yesterdayMatch = SyncSchedulePrivate::daysMatch(d_ptr->iDays, yesterday.dayOfWeek());
+        if (yesterdayMatch) {
+            qint64 diff = QDateTime(yesterday, d_ptr->iTime).secsTo(aActualDateTime);
+            if (diff < 0) {
+                diff = -diff;
+            }
+            minDiffSecs = qMin(minDiffSecs, diff);
+            qCDebug(lcButeoCore) << "Scheduled check (yesterday): scheduled=" << QDateTime(yesterday, d_ptr->iTime)
+                                 << "actual=" << aActualDateTime << "diffSecs=" << diff;
+        } else {
+            qCDebug(lcButeoCore) << "Scheduled check (yesterday): day mismatch, scheduledDays=" << d_ptr->iDays
+                                 << "yesterdayDayOfWeek=" << yesterday.dayOfWeek();
+        }
+
+        if (minDiffSecs == LLONG_MAX) {
+            qCDebug(lcButeoCore) << "Scheduled check result: rejected, no matching day candidate for explicit-time schedule.";
             return false;
         }
 
-        /* Keep a 10 minutes margin to ensure that delayed
-           syncs by more prioritary sync in progress are still
-           considered as valid sync times. */
-        return (aActualDateTime.time() < d_ptr->iTime.addSecs(5 * 60)
-                && aActualDateTime.time() > d_ptr->iTime.addSecs(-5 * 60));
+        const bool accepted = minDiffSecs <= toleranceSecs;
+        qCDebug(lcButeoCore) << "Scheduled check result:" << (accepted ? "accepted" : "rejected")
+                             << "minDiffSecs=" << minDiffSecs << "toleranceSecs=" << toleranceSecs;
+        return accepted;
     }
 
     // If sync schedule is defined by rush, check that rush is enabled for aActualDateTime

--- a/libbuteosyncfw/profile/SyncSchedule.h
+++ b/libbuteosyncfw/profile/SyncSchedule.h
@@ -285,6 +285,23 @@ public:
      */
     bool isSyncScheduled(const QDateTime &aActualDateTime, const QDateTime &aPreviousSyncTime = QDateTime()) const;
 
+    /*! \brief Gets per-schedule wakeup tolerance window in seconds.
+     *
+     * Used by isSyncScheduled() for explicit-time schedules to accept platform
+     * wakeups that drift from the scheduled time. A value of 0 means "use the
+     * built-in default tolerance".
+     *
+     * \return Tolerance in seconds, or 0 if not explicitly set.
+     */
+    unsigned int wakeupTolerance() const;
+
+    /*! \brief Sets per-schedule wakeup tolerance window in seconds.
+     *
+     * Set to 0 to fall back to the built-in default tolerance.
+     * \param aSeconds Tolerance in seconds.
+     */
+    void setWakeupTolerance(unsigned int aSeconds);
+
 private:
     SyncSchedulePrivate *d_ptr;
 

--- a/libbuteosyncfw/profile/SyncSchedule_p.h
+++ b/libbuteosyncfw/profile/SyncSchedule_p.h
@@ -120,6 +120,10 @@ public:
 
     //! Indicates if External Rush Hour schedule is Enabled
     bool iExternalRushEnabled;
+
+    //! Optional per-schedule wakeup tolerance in seconds.
+    //! 0 means "use default" (handled in SyncSchedule::isSyncScheduled()).
+    unsigned int iWakeupTolerance = 0;
 };
 
 }

--- a/msyncd/BackgroundSync.cpp
+++ b/msyncd/BackgroundSync.cpp
@@ -107,6 +107,10 @@ bool BackgroundSync::set(const QString &aProfName, int seconds)
                                        << "with frequency" << (seconds / 60) << "minutes, waiting.";
                 return true;
             } else {
+                // If the activity's state was already Waiting, the state doesn't change,
+                // nothing happens and the existing background activity keeps running until
+                // the previously set time expires, so we have to stop it before re-arming.
+                newAct.backgroundActivity->stop();
                 newAct.backgroundActivity->wait();
                 qCDebug(lcButeoMsyncd) << "BackgroundSync::set() Frequency unchanged for" << aProfName << ", waiting.";
                 return true; //returning 'true' - no immediate sync request to be sent.


### PR DESCRIPTION
See bug report: https://forum.sailfishos.org/t/automatic-daily-backup-only-works-once-after-creation/15563
and Claude Opus 4.6 analysis: https://github.com/Karry/buteo-syncfw/blob/sync-scheduling-issue/backup-issue-analysis-step01.md 

Daily and weekly backup seems to be reliable now.